### PR TITLE
feature: Added language visibility controls

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10660,16 +10660,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "273fd29ff30ba0a88ca5fb83f7cf1ab69306adae"
+                "reference": "492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/273fd29ff30ba0a88ca5fb83f7cf1ab69306adae",
-                "reference": "273fd29ff30ba0a88ca5fb83f7cf1ab69306adae",
+                "url": "https://api.github.com/repos/symfony/console/zipball/492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f",
+                "reference": "492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f",
                 "shasum": ""
             },
             "require": {
@@ -10734,7 +10734,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.25"
+                "source": "https://github.com/symfony/console/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -10754,7 +10754,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T10:21:53+00:00"
+            "time": "2025-09-26T12:13:46+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -10827,16 +10827,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "900da8a42eceeb4a13a0ec34caa7db49328daff3"
+                "reference": "5f311eaf0b321f8ec640f6bae12da43a14026898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/900da8a42eceeb4a13a0ec34caa7db49328daff3",
-                "reference": "900da8a42eceeb4a13a0ec34caa7db49328daff3",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5f311eaf0b321f8ec640f6bae12da43a14026898",
+                "reference": "5f311eaf0b321f8ec640f6bae12da43a14026898",
                 "shasum": ""
             },
             "require": {
@@ -10888,7 +10888,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.25"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -10908,7 +10908,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T09:41:44+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -11050,16 +11050,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.24",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "30fd0b3cf0e972e82636038ce4db0e4fe777112c"
+                "reference": "41bedcaec5b72640b0ec2096547b75fda72ead6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/30fd0b3cf0e972e82636038ce4db0e4fe777112c",
-                "reference": "30fd0b3cf0e972e82636038ce4db0e4fe777112c",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/41bedcaec5b72640b0ec2096547b75fda72ead6c",
+                "reference": "41bedcaec5b72640b0ec2096547b75fda72ead6c",
                 "shasum": ""
             },
             "require": {
@@ -11105,7 +11105,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.24"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11125,7 +11125,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-24T08:25:04+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -11427,16 +11427,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "b8e9dce2d8acba3c32af467bb58e0c3656886181"
+                "reference": "6740cdc1a3bffa127966b6056e883b3fe3709849"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/b8e9dce2d8acba3c32af467bb58e0c3656886181",
-                "reference": "b8e9dce2d8acba3c32af467bb58e0c3656886181",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/6740cdc1a3bffa127966b6056e883b3fe3709849",
+                "reference": "6740cdc1a3bffa127966b6056e883b3fe3709849",
                 "shasum": ""
             },
             "require": {
@@ -11501,7 +11501,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.25"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11521,7 +11521,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T07:01:16+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -11603,16 +11603,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6bc974c0035b643aa497c58d46d9e25185e4b272"
+                "reference": "369241591d92bb5dfb4c6ccd6ee94378a45b1521"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6bc974c0035b643aa497c58d46d9e25185e4b272",
-                "reference": "6bc974c0035b643aa497c58d46d9e25185e4b272",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/369241591d92bb5dfb4c6ccd6ee94378a45b1521",
+                "reference": "369241591d92bb5dfb4c6ccd6ee94378a45b1521",
                 "shasum": ""
             },
             "require": {
@@ -11660,7 +11660,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.25"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11680,20 +11680,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T06:48:20+00:00"
+            "time": "2025-09-16T08:22:30+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "a0ee3cea5cabf4ed960fd2ef57668ceeacdb6e15"
+                "reference": "8b0f963293aede77593c9845c8c0af34752e893a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a0ee3cea5cabf4ed960fd2ef57668ceeacdb6e15",
-                "reference": "a0ee3cea5cabf4ed960fd2ef57668ceeacdb6e15",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8b0f963293aede77593c9845c8c0af34752e893a",
+                "reference": "8b0f963293aede77593c9845c8c0af34752e893a",
                 "shasum": ""
             },
             "require": {
@@ -11778,7 +11778,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.25"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11798,20 +11798,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T07:55:45+00:00"
+            "time": "2025-09-27T12:20:56+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "628b43b45a3e6b15c8a633fb22df547ed9b492a2"
+                "reference": "012185cd31689b799d39505bd706be6d3a57cd3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/628b43b45a3e6b15c8a633fb22df547ed9b492a2",
-                "reference": "628b43b45a3e6b15c8a633fb22df547ed9b492a2",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/012185cd31689b799d39505bd706be6d3a57cd3f",
+                "reference": "012185cd31689b799d39505bd706be6d3a57cd3f",
                 "shasum": ""
             },
             "require": {
@@ -11862,7 +11862,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.4.25"
+                "source": "https://github.com/symfony/mailer/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11882,20 +11882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T09:41:44+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.24",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "664d5e844a2de5e11c8255d0aef6bc15a9660ac7"
+                "reference": "61ab9681cdfe315071eb4fa79b6ad6ab030a9235"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/664d5e844a2de5e11c8255d0aef6bc15a9660ac7",
-                "reference": "664d5e844a2de5e11c8255d0aef6bc15a9660ac7",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/61ab9681cdfe315071eb4fa79b6ad6ab030a9235",
+                "reference": "61ab9681cdfe315071eb4fa79b6ad6ab030a9235",
                 "shasum": ""
             },
             "require": {
@@ -11951,7 +11951,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.24"
+                "source": "https://github.com/symfony/mime/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -11971,7 +11971,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T12:02:45+00:00"
+            "time": "2025-09-16T08:22:30+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -12612,16 +12612,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8"
+                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
+                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
                 "shasum": ""
             },
             "require": {
@@ -12653,7 +12653,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.25"
+                "source": "https://github.com/symfony/process/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -12673,7 +12673,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-14T06:23:17+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -12764,16 +12764,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.24",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "e4f94e625c8e6f910aa004a0042f7b2d398278f5"
+                "reference": "6fc4c445f22857d4b8b40a02b73f423ddab295de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/e4f94e625c8e6f910aa004a0042f7b2d398278f5",
-                "reference": "e4f94e625c8e6f910aa004a0042f7b2d398278f5",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/6fc4c445f22857d4b8b40a02b73f423ddab295de",
+                "reference": "6fc4c445f22857d4b8b40a02b73f423ddab295de",
                 "shasum": ""
             },
             "require": {
@@ -12827,7 +12827,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.24"
+                "source": "https://github.com/symfony/routing/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -12847,20 +12847,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T08:46:37+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "26f877808e20da1c0f8bc366d54c726003b0088b"
+                "reference": "48d0477483614d615aa1d5e5d90a45e4c7bfa2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/26f877808e20da1c0f8bc366d54c726003b0088b",
-                "reference": "26f877808e20da1c0f8bc366d54c726003b0088b",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/48d0477483614d615aa1d5e5d90a45e4c7bfa2c9",
+                "reference": "48d0477483614d615aa1d5e5d90a45e4c7bfa2c9",
                 "shasum": ""
             },
             "require": {
@@ -12929,7 +12929,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.25"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -12949,7 +12949,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T11:31:57+00:00"
+            "time": "2025-09-15T13:37:27+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -13036,16 +13036,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "7cdec7edfaf2cdd9c18901e35bcf9653d6209ff1"
+                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/7cdec7edfaf2cdd9c18901e35bcf9653d6209ff1",
-                "reference": "7cdec7edfaf2cdd9c18901e35bcf9653d6209ff1",
+                "url": "https://api.github.com/repos/symfony/string/zipball/5621f039a71a11c87c106c1c598bdcd04a19aeea",
+                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea",
                 "shasum": ""
             },
             "require": {
@@ -13059,7 +13059,6 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
                 "symfony/http-client": "^5.4|^6.0|^7.0",
                 "symfony/intl": "^6.2|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
@@ -13102,7 +13101,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.25"
+                "source": "https://github.com/symfony/string/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13122,20 +13121,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T12:33:20+00:00"
+            "time": "2025-09-11T14:32:46+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.24",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "300b72643e89de0734d99a9e3f8494a3ef6936e1"
+                "reference": "c8559fe25c7ee7aa9d28f228903a46db008156a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/300b72643e89de0734d99a9e3f8494a3ef6936e1",
-                "reference": "300b72643e89de0734d99a9e3f8494a3ef6936e1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/c8559fe25c7ee7aa9d28f228903a46db008156a4",
+                "reference": "c8559fe25c7ee7aa9d28f228903a46db008156a4",
                 "shasum": ""
             },
             "require": {
@@ -13201,7 +13200,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.24"
+                "source": "https://github.com/symfony/translation/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13221,7 +13220,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T17:30:48+00:00"
+            "time": "2025-09-05T18:17:25+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -13303,16 +13302,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "9352177c0e937793423053846f80bee805552324"
+                "reference": "3ed456b3cd04e61fc7ed2601805fee3c1130663a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/9352177c0e937793423053846f80bee805552324",
-                "reference": "9352177c0e937793423053846f80bee805552324",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/3ed456b3cd04e61fc7ed2601805fee3c1130663a",
+                "reference": "3ed456b3cd04e61fc7ed2601805fee3c1130663a",
                 "shasum": ""
             },
             "require": {
@@ -13380,7 +13379,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.4.25"
+                "source": "https://github.com/symfony/validator/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13400,20 +13399,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T11:31:57+00:00"
+            "time": "2025-09-25T15:37:27+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c6cd92486e9fc32506370822c57bc02353a5a92c"
+                "reference": "cfae1497a2f1eaad78dbc0590311c599c7178d4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c6cd92486e9fc32506370822c57bc02353a5a92c",
-                "reference": "c6cd92486e9fc32506370822c57bc02353a5a92c",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cfae1497a2f1eaad78dbc0590311c599c7178d4a",
+                "reference": "cfae1497a2f1eaad78dbc0590311c599c7178d4a",
                 "shasum": ""
             },
             "require": {
@@ -13468,7 +13467,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.25"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13488,20 +13487,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T09:41:44+00:00"
+            "time": "2025-09-25T15:37:27+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "4ff50a1b7c75d1d596aca50899d0c8c7e3de8358"
+                "reference": "466fcac5fa2e871f83d31173f80e9c2684743bfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/4ff50a1b7c75d1d596aca50899d0c8c7e3de8358",
-                "reference": "4ff50a1b7c75d1d596aca50899d0c8c7e3de8358",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/466fcac5fa2e871f83d31173f80e9c2684743bfc",
+                "reference": "466fcac5fa2e871f83d31173f80e9c2684743bfc",
                 "shasum": ""
             },
             "require": {
@@ -13549,7 +13548,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.25"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13569,20 +13568,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-18T13:06:32+00:00"
+            "time": "2025-09-11T09:57:09+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.25",
+            "version": "v6.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e54b060bc9c3dc3d4258bf0d165d0064e755f565"
+                "reference": "0fc8b966fd0dcaab544ae59bfc3a433f048c17b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e54b060bc9c3dc3d4258bf0d165d0064e755f565",
-                "reference": "e54b060bc9c3dc3d4258bf0d165d0064e755f565",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0fc8b966fd0dcaab544ae59bfc3a433f048c17b0",
+                "reference": "0fc8b966fd0dcaab544ae59bfc3a433f048c17b0",
                 "shasum": ""
             },
             "require": {
@@ -13625,7 +13624,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.25"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.26"
             },
             "funding": [
                 {
@@ -13645,7 +13644,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-26T16:59:00+00:00"
+            "time": "2025-09-26T15:07:38+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/config/default/core.entity_form_display.group.country.default.yml
+++ b/config/default/core.entity_form_display.group.country.default.yml
@@ -11,8 +11,10 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
+
     - field.field.group.country.field_unicef_logo
     - group.type.country
   module:
@@ -121,5 +123,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_language_name_in_local: true
+  field_language_visibility_in_app: true
+
   path: true
   uid: true

--- a/config/default/core.entity_view_display.group.country.default.yml
+++ b/config/default/core.entity_view_display.group.country.default.yml
@@ -11,8 +11,10 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
+
     - field.field.group.country.field_unicef_logo
     - group.type.country
   module:
@@ -78,14 +80,6 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_language_name_in_local:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 6
-    region: content
   field_make_available_for_mobile:
     type: boolean
     label: above
@@ -100,12 +94,13 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
     weight: 1
     region: content
+
   field_unicef_logo:
     type: entity_reference_entity_view
     label: above
@@ -126,5 +121,7 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_name_in_local: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: 7d9ac84c-b963-4019-b601-c55ff0a4f01f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: 8a1b372e-3fc2-4dcc-a0ee-4ca2f355284f
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/workflows.workflow.editorial.yml
+++ b/config/default/workflows.workflow.editorial.yml
@@ -59,5 +59,18 @@ type_settings:
         - published
       to: published
       weight: 1
-  entity_types: {  }
+  entity_types:
+    node:
+      - article
+      - faq
+      - milestone
+      - page
+      - activities
+      - child_development
+      - child_growth
+      - daily_homescreen_messages
+      - health_check_ups
+      - survey
+      - vaccinations
+      - video_article
   default_moderation_state: draft

--- a/config_bangla/default/config_ignore.settings.yml
+++ b/config_bangla/default/config_ignore.settings.yml
@@ -1,9 +1,13 @@
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
+mode: simple
 ignored_config_entities:
-  - smtp.settings
-  - tmgmt.translator.memsource
   - google_analytics.settings
-  - mobile_app_links.ios
   - mobile_app_links.android
+  - mobile_app_links.ios
   - pb_custom_form.mobile_app_share_link_form
+  - smtp.settings
+  - tmgmt.translator.deepl_free
+  - tmgmt.translator.deepl_pro
+  - tmgmt.translator.google
+  - tmgmt.translator.memsource

--- a/config_bangla/default/core.entity_form_display.group.country.default.yml
+++ b/config_bangla/default/core.entity_form_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -121,5 +122,6 @@ content:
     third_party_settings: {  }
 hidden:
   field_language_name_in_local: true
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_bangla/default/core.entity_view_display.group.country.default.yml
+++ b/config_bangla/default/core.entity_view_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -79,7 +80,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -99,6 +100,7 @@ hidden:
   field_app_name: true
   field_content_toggle: true
   field_country_email: true
+  field_language_visibility_in_app: true
   field_unicef_logo: true
   langcode: true
   uid: true

--- a/config_bangla/default/core.extension.yml
+++ b/config_bangla/default/core.extension.yml
@@ -46,6 +46,7 @@ module:
   google_analytics: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -56,6 +57,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_bangla/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_bangla/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: 43de71d7-666d-40ef-b1b9-9b4e2a08b998
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_bangla/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_bangla/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: fcf1e504-d43e-494d-98c9-c92bd5eed4f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_bangla/default/language/ar/views.view.tmgmt_job_overview.yml
+++ b/config_bangla/default/language/ar/views.view.tmgmt_job_overview.yml
@@ -1,13 +1,6 @@
 display:
   default:
     display_options:
-      pager:
-        options:
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
       fields:
         label:
           label: التسمية
@@ -17,3 +10,10 @@ display:
           label: Tags
         operations:
           label: عمليات
+      pager:
+        options:
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'

--- a/config_ecuador/default/config_ignore.settings.yml
+++ b/config_ecuador/default/config_ignore.settings.yml
@@ -7,4 +7,7 @@ ignored_config_entities:
   - mobile_app_links.ios
   - pb_custom_form.mobile_app_share_link_form
   - smtp.settings
+  - tmgmt.translator.deepl_free
+  - tmgmt.translator.deepl_pro
+  - tmgmt.translator.google
   - tmgmt.translator.memsource

--- a/config_ecuador/default/core.entity_form_display.group.country.default.yml
+++ b/config_ecuador/default/core.entity_form_display.group.country.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.group.country.field_country_national_partner
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -119,5 +120,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_ecuador/default/core.entity_view_display.group.country.default.yml
+++ b/config_ecuador/default/core.entity_view_display.group.country.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.group.country.field_country_national_partner
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -91,7 +92,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -117,5 +118,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config_ecuador/default/core.extension.yml
+++ b/config_ecuador/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_ecuador/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_ecuador/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: ec8d0a52-42e5-436f-805b-7372ed286ad7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_ecuador/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_ecuador/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: 05a14e59-6c04-420f-8b39-a00ad28f905b
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_pacific_islands/default/block.block.claro_help_search.yml
+++ b/config_pacific_islands/default/block.block.claro_help_search.yml
@@ -1,3 +1,4 @@
+uuid: b3ebf7b4-8114-4067-9d39-166f0b3a5a56
 langcode: en
 status: true
 dependencies:

--- a/config_pacific_islands/default/core.entity_form_display.group.country.default.yml
+++ b/config_pacific_islands/default/core.entity_form_display.group.country.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.group.country.field_country_national_partner
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -119,5 +120,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_pacific_islands/default/core.entity_view_display.group.country.default.yml
+++ b/config_pacific_islands/default/core.entity_view_display.group.country.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.group.country.field_country_national_partner
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -91,7 +92,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -117,5 +118,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config_pacific_islands/default/core.extension.yml
+++ b/config_pacific_islands/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_pacific_islands/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_pacific_islands/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: eb288e69-8a3a-4027-a1cf-a4c6e42cf6fb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_pacific_islands/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_pacific_islands/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: c13e54f6-8c40-430e-92ad-2d2e689356af
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_pacific_islands/default/views.view.entity_share_client_entity_import_status.yml
+++ b/config_pacific_islands/default/views.view.entity_share_client_entity_import_status.yml
@@ -1,3 +1,4 @@
+uuid: f8e8d54e-fc10-403e-91bf-43f827d3cddb
 langcode: en
 status: true
 dependencies:

--- a/config_pacific_islands/default/views.view.tmgmt_translation_all_job_items.yml
+++ b/config_pacific_islands/default/views.view.tmgmt_translation_all_job_items.yml
@@ -696,6 +696,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -713,7 +714,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -3201,6 +3201,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -3218,7 +3219,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config_pacific_islands/default/views.view.user_admin_people.yml
+++ b/config_pacific_islands/default/views.view.user_admin_people.yml
@@ -465,6 +465,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -482,7 +483,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config_pacific_islands/default/views.view.users_list.yml
+++ b/config_pacific_islands/default/views.view.users_list.yml
@@ -466,6 +466,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -483,7 +484,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config_pacific_islands/default/views.view.users_reports.yml
+++ b/config_pacific_islands/default/views.view.users_reports.yml
@@ -474,6 +474,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -491,7 +492,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -1315,8 +1315,8 @@ display:
             link_to_entity: 0
             format:
               name: name
-              iso: 0
-              name_native: 0
+              iso: '0'
+              name_native: '0'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2414,8 +2414,8 @@ display:
             link_to_entity: 0
             format:
               name: name
-              iso: 0
-              name_native: 0
+              iso: '0'
+              name_native: '0'
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/config_pacific_islands/default/views.view.watchdog.yml
+++ b/config_pacific_islands/default/views.view.watchdog.yml
@@ -440,6 +440,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -454,7 +455,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config_somoa/default/config_ignore.settings.yml
+++ b/config_somoa/default/config_ignore.settings.yml
@@ -7,4 +7,7 @@ ignored_config_entities:
   - mobile_app_links.ios
   - pb_custom_form.mobile_app_share_link_form
   - smtp.settings
+  - tmgmt.translator.deepl_free
+  - tmgmt.translator.deepl_pro
+  - tmgmt.translator.google
   - tmgmt.translator.memsource

--- a/config_somoa/default/core.entity_form_display.group.country.default.yml
+++ b/config_somoa/default/core.entity_form_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -128,5 +129,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_somoa/default/core.entity_view_display.group.country.default.yml
+++ b/config_somoa/default/core.entity_view_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -100,7 +101,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -126,5 +127,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config_somoa/default/core.extension.yml
+++ b/config_somoa/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_somoa/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_somoa/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: a7c11ba2-f7ab-42c3-841e-c765985cfbdb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_somoa/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_somoa/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: 1aec98f1-1f33-4889-ada5-3f1549328504
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_turkey/default/config_ignore.settings.yml
+++ b/config_turkey/default/config_ignore.settings.yml
@@ -7,4 +7,7 @@ ignored_config_entities:
   - mobile_app_links.ios
   - pb_custom_form.mobile_app_share_link_form
   - smtp.settings
+  - tmgmt.translator.deepl_free
+  - tmgmt.translator.deepl_pro
+  - tmgmt.translator.google
   - tmgmt.translator.memsource

--- a/config_turkey/default/core.entity_form_display.group.country.default.yml
+++ b/config_turkey/default/core.entity_form_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -121,5 +122,6 @@ content:
     third_party_settings: {  }
 hidden:
   field_language_name_in_local: true
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_turkey/default/core.entity_view_display.group.country.default.yml
+++ b/config_turkey/default/core.entity_view_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -100,7 +101,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -126,5 +127,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config_turkey/default/core.extension.yml
+++ b/config_turkey/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_turkey/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_turkey/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: b7576fb0-aaef-468b-8ed0-7424c2b42bbf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_turkey/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_turkey/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: 51edb405-43f4-413f-9d29-143635cc3aa8
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_turkey/default/language/tr/views.view.tmgmt_job_overview.yml
+++ b/config_turkey/default/language/tr/views.view.tmgmt_job_overview.yml
@@ -2,24 +2,6 @@ display:
   default:
     display_title: 'Ana (master)'
     display_options:
-      exposed_form:
-        options:
-          submit_button: Uygula
-          reset_button_label: Sıfırla
-          exposed_sorts_label: 'Sıralama anahtarı'
-          sort_asc_label: Artan
-          sort_desc_label: Azalan
-      pager:
-        options:
-          expose:
-            items_per_page_label: 'Sayfa başına öğe sayısı'
-            items_per_page_options_all_label: '- Tümü -'
-            offset_label: 'Başlangıç değeri'
-          tags:
-            previous: '‹ önceki'
-            next: 'sonraki ›'
-            first: '« ilk'
-            last: 'son »'
       fields:
         state:
           label: Durum
@@ -37,6 +19,24 @@ display:
           label: Değişti
         operations:
           label: İşlemler
+      pager:
+        options:
+          tags:
+            next: 'sonraki ›'
+            previous: '‹ önceki'
+            first: '« ilk'
+            last: 'son »'
+          expose:
+            items_per_page_label: 'Sayfa başına öğe sayısı'
+            items_per_page_options_all_label: '- Tümü -'
+            offset_label: 'Başlangıç değeri'
+      exposed_form:
+        options:
+          submit_button: Uygula
+          reset_button_label: Sıfırla
+          exposed_sorts_label: 'Sıralama anahtarı'
+          sort_asc_label: Artan
+          sort_desc_label: Azalan
       filters:
         state:
           expose:

--- a/config_zimbabwe/default/config_ignore.settings.yml
+++ b/config_zimbabwe/default/config_ignore.settings.yml
@@ -7,4 +7,7 @@ ignored_config_entities:
   - mobile_app_links.ios
   - pb_custom_form.mobile_app_share_link_form
   - smtp.settings
+  - tmgmt.translator.deepl_free
+  - tmgmt.translator.deepl_pro
+  - tmgmt.translator.google
   - tmgmt.translator.memsource

--- a/config_zimbabwe/default/core.entity_form_display.group.country.default.yml
+++ b/config_zimbabwe/default/core.entity_form_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -121,5 +122,6 @@ content:
     third_party_settings: {  }
 hidden:
   field_language_name_in_local: true
+  field_language_visibility_in_app: true
   path: true
   uid: true

--- a/config_zimbabwe/default/core.entity_view_display.group.country.default.yml
+++ b/config_zimbabwe/default/core.entity_view_display.group.country.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.group.country.field_country_sponsor_logo
     - field.field.group.country.field_language
     - field.field.group.country.field_language_name_in_local
+    - field.field.group.country.field_language_visibility_in_app
     - field.field.group.country.field_make_available_for_mobile
     - field.field.group.country.field_master_language
     - field.field.group.country.field_unicef_logo
@@ -100,7 +101,7 @@ content:
     type: languagefield_default
     label: above
     settings:
-      link_to_entity: false
+      link_to_entity: 0
       format:
         name: name
     third_party_settings: {  }
@@ -126,5 +127,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_language_visibility_in_app: true
   langcode: true
   uid: true

--- a/config_zimbabwe/default/core.extension.yml
+++ b/config_zimbabwe/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   gnode: 0
   group: 0
   group_country_field: 0
+  group_permissions_merge: 0
   help: 0
   image: 0
   image_style_quality: 0
@@ -54,6 +55,7 @@ module:
   lang_dropdown: 0
   language: 0
   language_custom_field: 0
+  language_visibility_control: 0
   languagefield: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0

--- a/config_zimbabwe/default/field.field.group.country.field_language_visibility_in_app.yml
+++ b/config_zimbabwe/default/field.field.group.country.field_language_visibility_in_app.yml
@@ -1,0 +1,19 @@
+uuid: 3f4b83be-2686-4016-b893-5c7c60e82a2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_language_visibility_in_app
+    - group.type.country
+id: group.country.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+bundle: country
+label: 'Language Visibility in Mobile App'
+description: 'Languages visible in the mobile app for this country.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config_zimbabwe/default/field.storage.group.field_language_visibility_in_app.yml
+++ b/config_zimbabwe/default/field.storage.group.field_language_visibility_in_app.yml
@@ -1,0 +1,21 @@
+uuid: fdc63680-3b3d-4293-a8f1-c8ceef14524a
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_language_visibility_in_app
+field_name: field_language_visibility_in_app
+entity_type: group
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/group_permissions_merge/group_permissions_merge.info.yml
+++ b/docroot/modules/custom/group_permissions_merge/group_permissions_merge.info.yml
@@ -1,0 +1,7 @@
+name: Group Permissions Merge
+type: module
+description: 'Merges permissions from multiple groups for multi-country users'
+core_version_requirement: ^10 || ^11
+package: Custom
+dependencies:
+  - group:group

--- a/docroot/modules/custom/group_permissions_merge/group_permissions_merge.module
+++ b/docroot/modules/custom/group_permissions_merge/group_permissions_merge.module
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @file
+ * Group Permissions Merge module.
+ */
+
+use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupContentInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\group_permissions_merge\GroupPermissionsMergeService;
+
+/**
+ * Implements hook_group_permission_alter().
+ */
+function group_permissions_merge_group_permission_alter(array &$permissions, GroupInterface $group, AccountInterface $account) {
+  // Only process for users with editor, senior editor, or SME roles.
+  $user_roles = $account->getRoles();
+  $target_roles = GroupPermissionsMergeService::getTargetRoles();
+
+  if (!array_intersect($user_roles, $target_roles)) {
+    return;
+  }
+
+  // Get all groups the user belongs to.
+  $group_membership_loader = \Drupal::service('group.membership_loader');
+  $memberships = $group_membership_loader->loadByUser($account);
+
+  $merged_permissions = [];
+
+  foreach ($memberships as $membership) {
+    $group_roles = $membership->getRoles();
+
+    // Flatten permissions from all roles.
+    $role_permissions = array_reduce($group_roles, function ($carry, $role) {
+      return array_merge($carry, $role->getPermissions());
+    }, []);
+
+    $merged_permissions = array_merge($merged_permissions, $role_permissions);
+  }
+
+  // Merge with existing permissions and remove duplicates.
+  $permissions = array_unique(array_merge($permissions, $merged_permissions));
+}
+
+/**
+ * Implements hook_entity_access().
+ */
+function group_permissions_merge_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  try {
+    // Only handle node entities for multi-country access.
+    if ($entity->getEntityTypeId() !== 'node') {
+      return AccessResult::neutral();
+    }
+
+    return \Drupal::service('group_permissions_merge.service')->hasNodeAccess($account, $entity, $operation)
+      ? AccessResult::allowed()->addCacheContexts(['user.group_permissions'])
+      : AccessResult::neutral();
+  }
+  catch (\Exception $e) {
+    return AccessResult::neutral();
+  }
+}
+
+/**
+ * Implements hook_node_access().
+ */
+function group_permissions_merge_node_access(NodeInterface $node, $op, AccountInterface $account) {
+  try {
+    // Early return for unsupported operations.
+    if (!in_array($op, ['view', 'update'])) {
+      return AccessResult::neutral();
+    }
+
+    return \Drupal::service('group_permissions_merge.service')->hasNodeAccess($account, $node, $op)
+      ? AccessResult::allowed()->addCacheContexts(['user.group_permissions'])
+      : AccessResult::neutral();
+  }
+  catch (\Exception $e) {
+    return AccessResult::neutral();
+  }
+}
+
+/**
+ * Implements hook_group_content_update().
+ */
+function group_permissions_merge_group_content_update(GroupContentInterface $group_content) {
+  // Sync user allowed_languages when group membership changes.
+  if ($group_content->getContentPlugin()->getPluginId() === 'group_membership') {
+    _group_permissions_merge_sync_user_languages($group_content->getEntity());
+  }
+}
+
+/**
+ * Implements hook_group_content_delete().
+ */
+function group_permissions_merge_group_content_delete(GroupContentInterface $group_content) {
+  // Sync user allowed_languages when group membership is removed.
+  if ($group_content->getContentPlugin()->getPluginId() === 'group_membership') {
+    _group_permissions_merge_sync_user_languages($group_content->getEntity());
+  }
+}
+
+/**
+ * Helper function to sync user's allowed_languages field with group.
+ */
+function _group_permissions_merge_sync_user_languages(AccountInterface $user) {
+  try {
+    // Only sync for users with editor, senior editor, or SME roles.
+    $user_roles = $user->getRoles();
+    $target_roles = GroupPermissionsMergeService::getTargetRoles();
+
+    if (!array_intersect($user_roles, $target_roles)) {
+      return;
+    }
+
+    if (!$user->hasField('allowed_languages')) {
+      return;
+    }
+
+    $membership_loader = \Drupal::service('group.membership_loader');
+    $memberships = $membership_loader->loadByUser($user);
+
+    if (empty($memberships)) {
+      return;
+    }
+
+    $group_languages = [];
+    foreach ($memberships as $membership) {
+      $group = $membership->getGroup();
+      if ($group && $group->hasField('field_language') && !$group->get('field_language')->isEmpty()) {
+        $languages = $group->get('field_language')->getValue();
+        // Extract language values and filter.
+        $lang_values = array_filter(array_column($languages, 'value'));
+        $group_languages = array_unique(array_merge($group_languages, $lang_values));
+      }
+    }
+
+    // Get current user languages.
+    $current_langs = $user->get('allowed_languages')->getValue();
+    $current_langcodes = array_column($current_langs, 'target_id');
+
+    // Check if sync is needed.
+    $missing_languages = array_diff($group_languages, $current_langcodes);
+
+    if (!empty($missing_languages)) {
+      // Combine existing and missing languages.
+      $all_langcodes = array_unique(array_filter(array_merge($current_langcodes, $missing_languages)));
+
+      $unique_languages = array_map(function ($langcode) {
+        return ['target_id' => $langcode];
+      }, $all_langcodes);
+
+      $user->set('allowed_languages', $unique_languages);
+      $user->save();
+    }
+  }
+  catch (\Exception $e) {
+  }
+}

--- a/docroot/modules/custom/group_permissions_merge/group_permissions_merge.services.yml
+++ b/docroot/modules/custom/group_permissions_merge/group_permissions_merge.services.yml
@@ -1,0 +1,4 @@
+services:
+  group_permissions_merge.service:
+    class: Drupal\group_permissions_merge\GroupPermissionsMergeService
+    arguments: ['@group.membership_loader', '@entity_type.manager']

--- a/docroot/modules/custom/group_permissions_merge/src/GroupPermissionsMergeService.php
+++ b/docroot/modules/custom/group_permissions_merge/src/GroupPermissionsMergeService.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Drupal\group_permissions_merge;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\GroupMembershipLoaderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Service for merging group permissions across multiple countries.
+ */
+class GroupPermissionsMergeService {
+
+  /**
+   * The group membership loader.
+   *
+   * @var \Drupal\group\GroupMembershipLoaderInterface
+   */
+  protected $membershipLoader;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a GroupPermissionsMergeService object.
+   *
+   * @param \Drupal\group\GroupMembershipLoaderInterface $membership_loader
+   *   The group membership loader.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(GroupMembershipLoaderInterface $membership_loader, EntityTypeManagerInterface $entity_type_manager) {
+    $this->membershipLoader = $membership_loader;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Gets the target roles that should be processed by this module.
+   *
+   * @return array
+   *   Array of target role machine names.
+   */
+  public static function getTargetRoles() {
+    return ['editor', 'se', 'sme'];
+  }
+
+  /**
+   * Gets merged permissions for a user across all their group memberships.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   *
+   * @return array
+   *   Array of merged permissions.
+   */
+  public function getMergedPermissions(AccountInterface $account) {
+    try {
+      // Early return if user doesn't have target roles.
+      if (!array_intersect($account->getRoles(), self::getTargetRoles())) {
+        return [];
+      }
+
+      $memberships = $this->membershipLoader->loadByUser($account);
+      if (empty($memberships)) {
+        return [];
+      }
+
+      $merged_permissions = [];
+
+      foreach ($memberships as $membership) {
+        $group = $membership->getGroup();
+        if (!$group) {
+          continue;
+        }
+
+        // Extract permissions from all valid roles.
+        $role_permissions = array_reduce($membership->getRoles(), function ($carry, $role) {
+          return ($role && is_array($role->getPermissions()))
+            ? array_merge($carry, $role->getPermissions())
+            : $carry;
+        }, []);
+
+        $merged_permissions = array_merge($merged_permissions, $role_permissions);
+      }
+
+      return array_unique(array_filter($merged_permissions));
+    }
+    catch (\Exception $e) {
+      return [];
+    }
+  }
+
+  /**
+   * Checks if a user has access to a node through any of their group.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to check access for.
+   * @param string $operation
+   *   The operation (view, update, delete).
+   *
+   * @return bool
+   *   TRUE if user has access, FALSE otherwise.
+   */
+  public function hasNodeAccess(AccountInterface $account, $node, $operation) {
+    try {
+      // Early returns for validation.
+      if (!array_intersect($account->getRoles(), self::getTargetRoles()) ||
+          !in_array($operation, ['view', 'update'])) {
+        return FALSE;
+      }
+
+      $memberships = $this->membershipLoader->loadByUser($account);
+      if (empty($memberships)) {
+        return FALSE;
+      }
+
+      $group_content_storage = $this->entityTypeManager->getStorage('group_content');
+      $node_bundle = $node->bundle();
+
+      foreach ($memberships as $membership) {
+        $group = $membership->getGroup();
+        if (!$group) {
+          continue;
+        }
+
+        // Check if node belongs to this group.
+        $group_contents = $group_content_storage->loadByProperties([
+          'gid' => $group->id(),
+          'entity_id' => $node->id(),
+          'type' => 'country-group_node-' . $node_bundle,
+        ]);
+
+        // Check permissions if node belongs to group.
+        if (!empty($group_contents) &&
+            array_reduce($membership->getRoles(), function ($carry, $role) use ($node_bundle, $operation) {
+              return $carry || $this->hasRequiredPermission($role, $node_bundle, $operation);
+            }, FALSE)) {
+          return TRUE;
+        }
+      }
+
+      return FALSE;
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Checks if a group role has the required permission for an operation.
+   *
+   * @param \Drupal\group\Entity\GroupRoleInterface $group_role
+   *   The group role.
+   * @param string $bundle
+   *   The node bundle.
+   * @param string $operation
+   *   The operation.
+   *
+   * @return bool
+   *   TRUE if the role has the required permission.
+   */
+  protected function hasRequiredPermission($group_role, $bundle, $operation) {
+    if (!$group_role || empty($bundle) || empty($operation)) {
+      return FALSE;
+    }
+
+    $permissions = $group_role->getPermissions();
+    if (!is_array($permissions)) {
+      return FALSE;
+    }
+
+    // Define permission patterns for each operation.
+    $permission_patterns = [
+      'view' => [
+        'view unpublished group_node:' . $bundle . ' entity',
+        'view latest version',
+        'view group_node:' . $bundle . ' entity',
+      ],
+      'update' => [
+        'update any group_node:' . $bundle . ' entity',
+        'update own group_node:' . $bundle . ' entity',
+      ],
+      'delete' => [
+        'delete any group_node:' . $bundle . ' entity',
+        'delete own group_node:' . $bundle . ' entity',
+      ],
+    ];
+
+    return isset($permission_patterns[$operation]) &&
+           !empty(array_intersect($permission_patterns[$operation], $permissions));
+  }
+
+  /**
+   * Gets all workflow transition permissions for a user across all groups.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   *
+   * @return array
+   *   Array of workflow transition permissions.
+   */
+  public function getWorkflowTransitionPermissions(AccountInterface $account) {
+    $merged_permissions = $this->getMergedPermissions($account);
+
+    // Filter for workflow transition permissions.
+    $workflow_permissions = array_filter($merged_permissions, function ($permission) {
+      return strpos($permission, 'use group_workflow transition') === 0;
+    });
+
+    return $workflow_permissions;
+  }
+
+  /**
+   * Checks if a user can perform a specific workflow transition.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $transition_id
+   *   The workflow transition ID.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity (optional).
+   *
+   * @return bool
+   *   TRUE if user can perform the transition, FALSE otherwise.
+   */
+  public function canPerformWorkflowTransition(AccountInterface $account, $transition_id, $node = NULL) {
+    // Early return if user doesn't have target roles.
+    if (!array_intersect($account->getRoles(), self::getTargetRoles())) {
+      return FALSE;
+    }
+
+    $workflow_permissions = $this->getWorkflowTransitionPermissions($account);
+    $required_permission = 'use group_workflow transition ' . $transition_id;
+    $has_permission = in_array($required_permission, $workflow_permissions);
+
+    return $has_permission || ($node && $this->hasNodeAccess($account, $node, 'update') && $has_permission);
+  }
+
+}

--- a/docroot/modules/custom/language_visibility_control/js/admin.js
+++ b/docroot/modules/custom/language_visibility_control/js/admin.js
@@ -1,0 +1,179 @@
+(function ($, Drupal, once) {
+  'use strict';
+
+  /**
+   * Dynamic language visibility controls.
+   */
+  Drupal.behaviors.languageVisibilityControl = {
+    attach: function (context) {
+
+      // Watch for changes in the language field (both single and multiple select)
+      once('language-visibility', 'select[name*="field_language"]', context).forEach(function (element) {
+        $(element).on('change', function () {
+          updateVisibilityOptions();
+        });
+      });
+
+      // Also watch for changes in multi-value language fields
+      once('language-visibility-input', 'input[name*="field_language"]', context).forEach(function (element) {
+        $(element).on('change', function () {
+          updateVisibilityOptions();
+        });
+      });
+
+      /**
+       * Updates visibility options based on selected languages.
+       */
+      function updateVisibilityOptions() {
+        var selectedLanguages = getSelectedLanguages();
+        var $visibilityFieldset = $('[data-drupal-selector="edit-language-visibility"]');
+
+        if ($visibilityFieldset.length > 0) {
+          // Always ensure help messages and descriptions are visible
+          $visibilityFieldset.find('.language-visibility-help').show();
+          $visibilityFieldset.find('.language-visibility-description').show();
+          $visibilityFieldset.find('.form-item em').parent().show();
+
+          if (selectedLanguages.length === 0) {
+            // Hide all checkboxes but keep help messages and descriptions visible
+            $visibilityFieldset.find('.form-item').each(function() {
+              var $item = $(this);
+              if (!$item.find('.language-visibility-help').length &&
+                  !$item.find('em').length &&
+                  !$item.find('.language-visibility-description').length) {
+                $item.hide();
+              } else {
+                $item.show();
+              }
+            });
+          } else {
+            createVisibilityCheckboxes(selectedLanguages, $visibilityFieldset);
+          }
+        }
+      }
+
+      /**
+       * Gets currently selected languages from form fields.
+       */
+      function getSelectedLanguages() {
+        var selectedLanguages = [];
+
+        // Get selected languages from select field(s)
+        $('select[name*="field_language"] option:selected').each(function () {
+          var val = $(this).val();
+          if (val && val !== '_none' && val !== '') {
+            selectedLanguages.push(val);
+          }
+        });
+
+        // Also check for multi-value text inputs (if using a different widget)
+        $('input[name*="field_language"]:checked').each(function () {
+          var val = $(this).val();
+          if (val && val !== '_none' && val !== '') {
+            selectedLanguages.push(val);
+          }
+        });
+
+        return selectedLanguages;
+      }
+
+      /**
+       * Creates or shows visibility checkboxes for selected languages.
+       */
+      function createVisibilityCheckboxes(selectedLanguages, $fieldset) {
+        // Always ensure description elements are visible
+        $fieldset.find('.language-visibility-description').show();
+        $fieldset.find('.language-visibility-checkbox-description').show();
+
+        // First, hide all existing checkboxes but keep help messages and descriptions visible
+        $fieldset.find('.form-item').each(function() {
+          var $item = $(this);
+          if (!$item.find('.language-visibility-help').length &&
+              !$item.find('em').length &&
+              !$item.find('.language-visibility-description').length &&
+              !$item.find('.language-visibility-checkbox-description').length) {
+            $item.hide();
+          } else {
+            $item.show();
+          }
+        });
+
+        // For each selected language, show or create a checkbox and its description
+        selectedLanguages.forEach(function (langcode) {
+          var $existingCheckbox = $fieldset.find('input[name="language_visibility[' + langcode + ']"]');
+
+          if ($existingCheckbox.length > 0) {
+            // Show existing checkbox and its description
+            $existingCheckbox.closest('.form-item').show();
+            $fieldset.find('[data-drupal-selector*="' + langcode + '-description"]').show();
+          } else {
+            // Create new checkbox dynamically
+            createLanguageCheckbox(langcode, $fieldset);
+          }
+        });
+
+        // Uncheck and hide checkboxes for unselected languages
+        $fieldset.find('input[type="checkbox"]').each(function () {
+          var $checkbox = $(this);
+          var nameAttr = $checkbox.attr('name');
+
+          if (nameAttr) {
+            var matches = nameAttr.match(/language_visibility\[([^\]]+)\]/);
+            if (matches && matches[1]) {
+              var langcode = matches[1];
+              var $formItem = $checkbox.closest('.form-item');
+
+              if (selectedLanguages.indexOf(langcode) === -1) {
+                $formItem.hide();
+                $checkbox.prop('checked', false);
+                // Also hide the description for this language
+                $fieldset.find('[data-drupal-selector*="' + langcode + '-description"]').hide();
+              }
+            }
+          }
+        });
+      }
+
+      /**
+       * Creates a new language checkbox element.
+       */
+      function createLanguageCheckbox(langcode, $fieldset) {
+        var languageName = getLanguageName(langcode) || langcode;
+
+        var checkboxHtml = '<div class="form-item form-type-checkbox form-item-language-visibility-' + langcode + '">' +
+          '<input type="checkbox" id="edit-language-visibility-' + langcode + '" ' +
+          'name="language_visibility[' + langcode + ']" value="1" class="form-checkbox">' +
+          '<label class="option" for="edit-language-visibility-' + langcode + '">' +
+          languageName + ' (' + langcode + ')' +
+          '</label>' +
+          '</div>';
+
+        $fieldset.append(checkboxHtml);
+      }
+
+
+
+      /**
+       * Gets language name from Drupal settings.
+       */
+      function getLanguageName(langcode) {
+        var availableLanguages = drupalSettings.languageVisibilityControl ?
+          drupalSettings.languageVisibilityControl.availableLanguages : {};
+        return availableLanguages[langcode];
+      }
+
+      // Initial update on page load
+      setTimeout(function() {
+        updateVisibilityOptions();
+      }, 100);
+
+      // Also update when the form is rebuilt (AJAX)
+      $(document).on('ajaxComplete', function () {
+        setTimeout(function() {
+          updateVisibilityOptions();
+        }, 100);
+      });
+    }
+  };
+
+})(jQuery, Drupal, once);

--- a/docroot/modules/custom/language_visibility_control/language_visibility_control.info.yml
+++ b/docroot/modules/custom/language_visibility_control/language_visibility_control.info.yml
@@ -1,0 +1,8 @@
+name: Language Visibility Control
+type: module
+description: 'Controls when languages appear in the mobile app API without preventing editors from working on them'
+core_version_requirement: ^10 || ^11
+package: Custom
+dependencies:
+  - group:group
+  - drupal:language

--- a/docroot/modules/custom/language_visibility_control/language_visibility_control.install
+++ b/docroot/modules/custom/language_visibility_control/language_visibility_control.install
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for Language Visibility Control.
+ */
+
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
+
+/**
+ * Implements hook_install().
+ */
+function language_visibility_control_install() {
+  // Create the field storage for language visibility in mobile app.
+  if (!FieldStorageConfig::loadByName('group', 'field_language_visibility_in_app')) {
+    FieldStorageConfig::create([
+      'field_name' => 'field_language_visibility_in_app',
+      'entity_type' => 'group',
+      'type' => 'string',
+      'cardinality' => -1,
+      'settings' => [
+        'max_length' => 32,
+      ],
+    ])->save();
+  }
+
+  // Attach the field to the country group bundle if not already attached.
+  if (!FieldConfig::loadByName('group', 'country', 'field_language_visibility_in_app')) {
+    FieldConfig::create([
+      'field_name' => 'field_language_visibility_in_app',
+      'entity_type' => 'group',
+      'bundle' => 'country',
+      'label' => 'Language Visibility in Mobile App',
+      'description' => 'Languages visible in the mobile app for this country.',
+      'required' => FALSE,
+      'settings' => [],
+    ])->save();
+  }
+}

--- a/docroot/modules/custom/language_visibility_control/language_visibility_control.libraries.yml
+++ b/docroot/modules/custom/language_visibility_control/language_visibility_control.libraries.yml
@@ -1,0 +1,8 @@
+admin:
+  version: 1.x
+  js:
+    js/admin.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/once

--- a/docroot/modules/custom/language_visibility_control/language_visibility_control.module
+++ b/docroot/modules/custom/language_visibility_control/language_visibility_control.module
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * @file
+ * Language Visibility Control module.
+ */
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\group\Entity\Group;
+
+/**
+ * Implements hook_form_alter().
+ */
+function language_visibility_control_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Alter the country group form to add language visibility controls.
+  if ($form_id === 'group_country_edit_form' || $form_id === 'group_country_add_form') {
+    $group = $form_state->getFormObject()->getEntity();
+
+    // Attach JS behavior and language data.
+    $form['#attached']['library'][] = 'language_visibility_control/admin';
+
+    // Load and prepare language options for JS.
+    $all_languages = \Drupal::languageManager()->getLanguages();
+    $language_options = array_map(function ($language) {
+      return $language->getName();
+    }, $all_languages);
+
+    $form['#attached']['drupalSettings']['languageVisibilityControl']['availableLanguages'] = $language_options;
+
+    // Always add the language visibility fieldset.
+    $form['language_visibility'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Language Visibility in Mobile App'),
+      '#weight' => 50,
+      '#tree' => TRUE,
+      '#prefix' => '<div id="language-visibility-wrapper">',
+      '#suffix' => '</div>',
+      '#attributes' => [
+        'data-drupal-selector' => 'edit-language-visibility',
+      ],
+    ];
+
+    // Always add the fieldset description as a separate element.
+    $form['language_visibility']['fieldset_description'] = [
+      '#type' => 'markup',
+      '#markup' => '<div class="language-visibility-description">Control which of the selected languages above should appear in the mobile app API. Languages not checked here can still be edited by users but will not be visible in the mobile app.</div>',
+      '#weight' => -90,
+      '#attributes' => [],
+    ];
+
+    // Modify the existing language field to add visibility controls.
+    if (isset($form['field_language'])) {
+      // Add description to the language field.
+      $form['field_language']['widget']['#description'] = t('Select languages for this country. Use the "Language Visibility" section below to control which languages appear in the mobile app.');
+
+      // Update the fieldset weight to be relative to the language field.
+      $form['language_visibility']['#weight'] = $form['field_language']['#weight'] + 1;
+
+      // Get currently selected languages.
+      $current_languages = _language_visibility_control_get_selected_languages($form_state, $group);
+
+      // Get currently visible languages.
+      $visible_languages = _language_visibility_control_get_visible_languages($form_state, $group);
+
+      // Add checkboxes only for currently selected languages.
+      foreach (array_unique($current_languages) as $langcode) {
+        if (isset($all_languages[$langcode])) {
+          $language_name = $all_languages[$langcode]->getName();
+          $form['language_visibility'][$langcode] = [
+            '#type' => 'checkbox',
+            '#title' => t('@language (@code)', [
+              '@language' => $language_name,
+              '@code' => $langcode,
+            ]),
+            '#default_value' => in_array($langcode, $visible_languages),
+          ];
+        }
+      }
+
+      // Add help text if no languages are selected.
+      if (empty($current_languages)) {
+        $form['language_visibility']['help'] = [
+          '#type' => 'markup',
+          '#markup' => '<p><em>' . t('Select languages above to configure their visibility in the mobile app.') . '</em></p>',
+        ];
+      }
+
+      // Add custom validation and submit handlers.
+      $form['#validate'][] = 'language_visibility_control_group_form_validate';
+
+      // Add submit handler BEFORE the main entity save.
+      array_unshift($form['actions']['submit']['#submit'], 'language_visibility_control_group_form_submit');
+    }
+  }
+}
+
+/**
+ * Custom validation handler for group forms.
+ */
+function language_visibility_control_group_form_validate($form, FormStateInterface $form_state) {
+  // Simple validation - just ensure we have valid data.
+  $language_visibility = $form_state->getValue('language_visibility');
+
+  if ($language_visibility && !is_array($language_visibility)) {
+    $form_state->setErrorByName('language_visibility', t('Invalid language visibility data.'));
+  }
+}
+
+/**
+ * Custom submit handler for group forms.
+ */
+function language_visibility_control_group_form_submit($form, FormStateInterface $form_state) {
+  // Prefer structured values from Form API when available.
+  $language_visibility = $form_state->getValue('language_visibility');
+  // Fall back to raw user input.
+  if (empty($language_visibility)) {
+    $user_input = $form_state->getUserInput();
+    if (isset($user_input['language_visibility']) && is_array($user_input['language_visibility'])) {
+      $language_visibility = $user_input['language_visibility'];
+    }
+  }
+
+  if (!empty($language_visibility)) {
+    $visible_langcodes = [];
+    foreach ($language_visibility as $langcode => $visible) {
+      // Accept truthy values: '1', 1, 'on', true.
+      if (is_string($langcode) && ($visible === 1 || $visible === '1' || $visible === 'on' || $visible === TRUE)) {
+        $visible_langcodes[] = $langcode;
+      }
+    }
+
+    // Get selected languages to validate against.
+    $group = $form_state->getFormObject()->getEntity();
+    $selected_country_langcodes = _language_visibility_control_get_selected_languages($form_state, $group);
+
+    // Filter visible languages to only include selected ones.
+    $valid_visible_langcodes = array_values(array_intersect($visible_langcodes, $selected_country_langcodes));
+
+    if ($group && $group->hasField('field_language_visibility_in_app') && !empty($valid_visible_langcodes)) {
+      $visible_languages = array_map(function ($code) {
+        return ['value' => $code];
+      }, $valid_visible_langcodes);
+
+      $group->set('field_language_visibility_in_app', $visible_languages);
+    }
+  }
+}
+
+/**
+ * Helper function to filter languages based on visibility settings.
+ *
+ * This function is called from the custom serializer.
+ */
+function language_visibility_control_filter_languages($languages, $group_id) {
+  $group = Group::load($group_id);
+  if (!$group) {
+    return $languages;
+  }
+
+  $service = \Drupal::service('language_visibility_control.service');
+  return $service->filterLanguageDataForApi($languages, $group);
+}
+
+/**
+ * Helper function to get selected languages from form state or entity.
+ */
+function _language_visibility_control_get_selected_languages($form_state, $group) {
+  $current_languages = [];
+  $user_input = $form_state->getUserInput();
+
+  // Extract languages from user input.
+  if (isset($user_input['field_language'])) {
+    $input_val = $user_input['field_language'];
+
+    if (is_array($input_val)) {
+      $current_languages = array_filter(array_map(function ($item) {
+        if (is_array($item) && !empty($item['value'])) {
+          return $item['value'];
+        }
+        elseif (is_string($item) && $item !== '' && $item !== '_none') {
+          return $item;
+        }
+        return NULL;
+      }, $input_val));
+    }
+    elseif (is_string($input_val) && $input_val !== '' && $input_val !== '_none') {
+      $current_languages[] = $input_val;
+    }
+  }
+
+  // Fallback to entity values if no user input.
+  if (empty($current_languages) && $group && $group->hasField('field_language') && !$group->get('field_language')->isEmpty()) {
+    $current_languages = array_filter(array_column($group->get('field_language')->getValue(), 'value'));
+  }
+
+  return array_unique($current_languages);
+}
+
+/**
+ * Helper function to get visible languages from form state or entity.
+ */
+function _language_visibility_control_get_visible_languages($form_state, $group) {
+  $visible_languages = [];
+  $user_input = $form_state->getUserInput();
+
+  // Extract from user input.
+  if (isset($user_input['language_visibility']) && is_array($user_input['language_visibility'])) {
+    $excluded_keys = ['help_message', 'help', 'fieldset_description'];
+
+    $visible_languages = array_keys(array_filter($user_input['language_visibility'], function ($checked, $langcode) use ($excluded_keys) {
+      return !in_array($langcode, $excluded_keys) &&
+             !str_ends_with($langcode, '_description') &&
+             !empty($checked);
+    }, ARRAY_FILTER_USE_BOTH));
+  }
+  // Fallback to entity values.
+  elseif ($group && $group->hasField('field_language_visibility_in_app') && !$group->get('field_language_visibility_in_app')->isEmpty()) {
+    $visible_languages = array_filter(array_column($group->get('field_language_visibility_in_app')->getValue(), 'value'));
+  }
+
+  return $visible_languages;
+}
+
+/**
+ * Implements hook_help().
+ */
+function language_visibility_control_help($route_name, $route_match) {
+  switch ($route_name) {
+    case 'help.page.language_visibility_control':
+      $output = '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('The Language Visibility Control module allows you to control which languages appear in the mobile app API for country groups.') . '</p>';
+
+      // Check if field exists.
+      $field_config = FieldConfig::loadByName('group', 'country', 'field_language_visibility_in_app');
+      if ($field_config) {
+        $output .= '<p><strong>' . t('Status: Field is properly configured.') . '</strong></p>';
+      }
+      else {
+        $output .= '<p><strong style="color: red;">' . t('Warning: Field is not configured. Please reinstall the module.') . '</strong></p>';
+      }
+
+      return $output;
+  }
+}

--- a/docroot/modules/custom/language_visibility_control/language_visibility_control.services.yml
+++ b/docroot/modules/custom/language_visibility_control/language_visibility_control.services.yml
@@ -1,0 +1,10 @@
+services:
+  language_visibility_control.service:
+    class: Drupal\language_visibility_control\LanguageVisibilityService
+    arguments: ['@entity_type.manager', '@language_manager']
+
+  language_visibility_control.api_response_subscriber:
+    class: Drupal\language_visibility_control\EventSubscriber\ApiResponseSubscriber
+    arguments: ['@language_visibility_control.service']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/language_visibility_control/src/EventSubscriber/ApiResponseSubscriber.php
+++ b/docroot/modules/custom/language_visibility_control/src/EventSubscriber/ApiResponseSubscriber.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\language_visibility_control\EventSubscriber;
+
+use Drupal\group\Entity\Group;
+use Drupal\language_visibility_control\LanguageVisibilityService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Event subscriber to modify API responses for language visibility.
+ */
+class ApiResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The language visibility service.
+   *
+   * @var \Drupal\language_visibility_control\LanguageVisibilityService
+   */
+  protected $languageVisibilityService;
+
+  /**
+   * Constructs an ApiResponseSubscriber object.
+   *
+   * @param \Drupal\language_visibility_control\LanguageVisibilityService $language_visibility_service
+   *   The language visibility service.
+   */
+  public function __construct(LanguageVisibilityService $language_visibility_service) {
+    $this->languageVisibilityService = $language_visibility_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::RESPONSE => ['onResponse', -10],
+    ];
+  }
+
+  /**
+   * Modifies API responses to filter languages based on visibility settings.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event.
+   */
+  public function onResponse(ResponseEvent $event) {
+    $request = $event->getRequest();
+    $response = $event->getResponse();
+
+    // Only process API requests for country-groups.
+    if (strpos($request->getPathInfo(), '/api/country-groups') === FALSE) {
+      return;
+    }
+
+    $content = $response->getContent();
+    if (empty($content)) {
+      return;
+    }
+
+    $data = json_decode($content, TRUE);
+    if (json_last_error() !== JSON_ERROR_NONE || !isset($data['data'])) {
+      return;
+    }
+
+    // Filter languages for each country group.
+    foreach ($data['data'] as &$country_data) {
+      if (isset($country_data['CountryID']) && isset($country_data['languages'])) {
+        $group = Group::load($country_data['CountryID']);
+        if ($group) {
+          $country_data['languages'] = $this->languageVisibilityService->filterLanguageDataForApi(
+            $country_data['languages'],
+            $group
+          );
+        }
+      }
+    }
+
+    $response->setContent(json_encode($data));
+  }
+
+}

--- a/docroot/modules/custom/language_visibility_control/src/LanguageVisibilityService.php
+++ b/docroot/modules/custom/language_visibility_control/src/LanguageVisibilityService.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Drupal\language_visibility_control;
+
+use Drupal\group\Entity\Group;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+
+/**
+ * Service for managing language visibility in mobile app API.
+ */
+class LanguageVisibilityService {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs a LanguageVisibilityService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LanguageManagerInterface $language_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * Gets all languages configured for a group.
+   *
+   * @param \Drupal\group\Entity\Group $group
+   *   The group entity.
+   *
+   * @return array
+   *   Array of all language codes for the group.
+   */
+  public function getAllGroupLanguages(Group $group) {
+    $languages = [];
+
+    if ($group->hasField('field_language') && !$group->get('field_language')->isEmpty()) {
+      $values = $group->get('field_language')->getValue();
+      foreach ($values as $value) {
+        $languages[] = $value['value'];
+      }
+    }
+
+    return $languages;
+  }
+
+  /**
+   * Gets visible languages for a group.
+   *
+   * @param \Drupal\group\Entity\Group $group
+   *   The group entity.
+   *
+   * @return array
+   *   Array of visible language codes for the group.
+   */
+  public function getVisibleLanguages(Group $group) {
+    $visible_languages = [];
+
+    if ($group->hasField('field_language_visibility_in_app') && !$group->get('field_language_visibility_in_app')->isEmpty()) {
+      $values = $group->get('field_language_visibility_in_app')->getValue();
+      foreach ($values as $value) {
+        if (!empty($value['value'])) {
+          $visible_languages[] = $value['value'];
+        }
+      }
+    }
+
+    return $visible_languages;
+  }
+
+  /**
+   * Filters language data for API based on visibility settings.
+   *
+   * @param array $languages
+   *   The original languages array.
+   * @param \Drupal\group\Entity\Group $group
+   *   The group entity.
+   *
+   * @return array
+   *   Filtered languages array containing only visible languages.
+   */
+  public function filterLanguageDataForApi(array $languages, Group $group) {
+    $visible_languages = $this->getVisibleLanguages($group);
+    $all_group_languages = $this->getAllGroupLanguages($group);
+
+    // If no visibility settings are configured, filter to only include
+    // languages that are actually configured for this group.
+    if (empty($visible_languages)) {
+      if (empty($all_group_languages)) {
+        // If group has no languages configured, return all languages (fallback)
+        return $languages;
+      }
+
+      // Filter to only include group's configured languages.
+      $filtered_languages = [];
+      foreach ($languages as $language) {
+        $langcode = $this->extractLanguageCode($language);
+        if (in_array($langcode, $all_group_languages)) {
+          $filtered_languages[] = $language;
+        }
+      }
+      return $filtered_languages;
+    }
+
+    // Filter languages to only include visible ones.
+    $filtered_languages = [];
+    foreach ($languages as $language) {
+      $langcode = $this->extractLanguageCode($language);
+      if (in_array($langcode, $visible_languages)) {
+        $filtered_languages[] = $language;
+      }
+    }
+
+    return $filtered_languages;
+  }
+
+  /**
+   * Extracts language code from different language data structures.
+   *
+   * @param mixed $language
+   *   The language data (array or string).
+   *
+   * @return string
+   *   The extracted language code.
+   */
+  private function extractLanguageCode($language) {
+    if (is_array($language) && isset($language['langcode'])) {
+      return $language['langcode'];
+    }
+    elseif (is_array($language) && isset($language['code'])) {
+      return $language['code'];
+    }
+    elseif (is_string($language)) {
+      return $language;
+    }
+
+    return '';
+  }
+
+  /**
+   * Gets language visibility statistics.
+   *
+   * @return array
+   *   Array containing visibility statistics.
+   */
+  public function getLanguageVisibilityStats() {
+    $stats = [
+      'total_groups' => 0,
+      'groups_with_visibility_settings' => 0,
+      'total_languages' => 0,
+      'visible_languages' => 0,
+      'hidden_languages' => 0,
+    ];
+
+    $groups = $this->entityTypeManager->getStorage('group')->loadByProperties(['type' => 'country']);
+    $stats['total_groups'] = count($groups);
+
+    foreach ($groups as $group) {
+      $all_languages = $this->getAllGroupLanguages($group);
+      $visible_languages = $this->getVisibleLanguages($group);
+
+      $stats['total_languages'] += count($all_languages);
+      $stats['visible_languages'] += count($visible_languages);
+      $stats['hidden_languages'] += count($all_languages) - count($visible_languages);
+
+      if (!empty($visible_languages)) {
+        $stats['groups_with_visibility_settings']++;
+      }
+    }
+
+    return $stats;
+  }
+
+  /**
+   * Debug method to check language visibility configuration for a group.
+   *
+   * @param \Drupal\group\Entity\Group $group
+   *   The group entity.
+   *
+   * @return array
+   *   Debug information about the group's language configuration.
+   */
+  public function debugGroupLanguageConfig(Group $group) {
+    $debug_info = [
+      'group_id' => $group->id(),
+      'group_label' => $group->label(),
+      'has_language_field' => $group->hasField('field_language'),
+      'has_visibility_field' => $group->hasField('field_language_visibility_in_app'),
+      'all_languages' => $this->getAllGroupLanguages($group),
+      'visible_languages' => $this->getVisibleLanguages($group),
+    ];
+
+    // Add raw field values for debugging.
+    if ($group->hasField('field_language')) {
+      $debug_info['raw_language_field'] = $group->get('field_language')->getValue();
+    }
+
+    if ($group->hasField('field_language_visibility_in_app')) {
+      $debug_info['raw_visibility_field'] = $group->get('field_language_visibility_in_app')->getValue();
+    }
+
+    return $debug_info;
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_form/pb_custom_form.module
+++ b/docroot/modules/custom/pb_custom_form/pb_custom_form.module
@@ -205,7 +205,7 @@ function pb_custom_form_form_alter(&$form, FormStateInterface $form_state, $form
     }
     /* $form['#attached']['js'][] = drupal_get_path('module', 'pb_custom_field') . '/js/homepage.js'; */
     $form['#attached']['library'][] = 'pb_custom_field/mylib';
-    $form['actions']['submit']['#submit'][] = 'group_country_save';
+    $form['actions']['submit']['#submit'][] = 'pb_custom_form_group_country_save';
   }
   if (strpos($form_id, 'edit_form') !== FALSE && strpos($form_id, 'node') !== FALSE) {
     $form['#validate'][] = 'pb_custom_form_node_validate';

--- a/docroot/sites/bangladesh/services.yml
+++ b/docroot/sites/bangladesh/services.yml
@@ -4,3 +4,4 @@ services:
     arguments: []
     tags:
       - { name: logger }
+

--- a/docroot/sites/ecuador/services.yml
+++ b/docroot/sites/ecuador/services.yml
@@ -4,3 +4,4 @@ services:
     arguments: []
     tags:
       - { name: logger }
+

--- a/docroot/sites/pacific_islands/services.yml
+++ b/docroot/sites/pacific_islands/services.yml
@@ -4,3 +4,4 @@ services:
     arguments: []
     tags:
       - { name: logger }
+

--- a/docroot/sites/somoa/services.yml
+++ b/docroot/sites/somoa/services.yml
@@ -4,3 +4,4 @@ services:
     arguments: []
     tags:
       - { name: logger }
+

--- a/docroot/sites/turkey/services.yml
+++ b/docroot/sites/turkey/services.yml
@@ -4,3 +4,4 @@ services:
     arguments: []
     tags:
       - { name: logger }
+


### PR DESCRIPTION
Users having assigned to two different countries are now able to edit the content from both the countries.
Added " Language Visibility in Mobile App" field while adding group to filter the APIs to display languages from app.

Tested below things on dev
- Users with Editor, Senior Editor and SME roles that are assigned to more than 1 language in more than 1 country can edit and successfully save changes.
- Users with Editor, Senior Editor and SME roles that are assigned to more than 1 language in more than 1 country can change Moderation State and successfully save. Specifically:
- Editors can change from Review After Translation to Draft
- SMEs can change from SME Review to Senior Editor Review
- Senior Editors can change from Senior Editor Review to Review After Translation, Draft, SME Review, Published
- Administrator can select one or more languages assigned to a country to be visible on the mobile app.
country-groups API lists only the languages selected to be visible on the mobile app.