### PR TITLE
Fix: Pregnancy term incorrectly appearing in taxonomy API

### DIFF
--- a/docroot/modules/custom/custom_serialization/src/Plugin/views/style/CustomSerializer.php
+++ b/docroot/modules/custom/custom_serialization/src/Plugin/views/style/CustomSerializer.php
@@ -560,7 +560,7 @@ class CustomSerializer extends Serializer {
             }
             else {
               // To hide pregnancy term in child age taxo.
-              $term_name_arr = ['pregnancy'];
+              $term_name_arr = ['Pregnancy'];
             }
           }
           // Use helper service for batch term loading instead of loading


### PR DESCRIPTION
Fixed case-sensitivity mismatch where code used 'pregnancy' (lowercase) but database contains 'Pregnancy' (capital P). The loadByProperties() method is case-sensitive, causing the filter to fail and Pregnancy term to appear even when pregnancy=true parameter was not provided.

- Changed line 563 from ['pregnancy'] to ['Pregnancy']
- Aligns with existing usage at lines 550 and 481
- Fixes issue across all sites and mobile applications