### PR TITLE
Refactor CI/CD pipeline to introduce develop branch for Dev deployments.

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -3,15 +3,14 @@ name: Acquia CI/CD Pipeline
 on:
   push:
     branches:
-      - 'feature/**'
-      - 'bug/**'
-      - 'hotfix/**'
+      - 'develop'
       - 'main'
   pull_request:
     branches:
       - 'feature/**'
       - 'bug/**'
       - 'hotfix/**'
+      - 'develop'
       - 'main'
   workflow_dispatch:
 
@@ -52,7 +51,7 @@ jobs:
   deploy-dev:
     needs: ci-checks
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/bug/'))
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v3
 
@@ -63,7 +62,6 @@ jobs:
           extensions: mbstring, pdo, xml, gd, curl, zip, bcmath, intl
 
       - run: |
-          composer validate --no-check-all --ansi
           composer install --prefer-dist --no-progress --no-interaction
 
       - name: Install Acquia CLI


### PR DESCRIPTION
1. Push triggers: Replaced feature/**, bug/**, hotfix/** with develop (alongside main).
2. PR targets: Added develop as a new target branch for pull requests.
3. deploy-dev condition: Changed from deploying on pushes to feature/* or bug/* branches → now only deploys when pushing to develop.
4. deploy-dev step: Removed composer validate --no-check-all --ansi from the dev deploy job.