### PR TITLE
Add vaccination support to v2 API and refactor BebboSerializer helpers

### DIFF
--- a/config/sync/core.entity_form_display.node.vaccinations.default.yml
+++ b/config/sync/core.entity_form_display.node.vaccinations.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.vaccinations.field_pinned_article
     - field.field.node.vaccinations.field_pinned_video_article
     - field.field.node.vaccinations.field_pre_populated
+    - field.field.node.vaccinations.field_related_articles_vacci
     - field.field.node.vaccinations.field_vaccination_closes
     - field.field.node.vaccinations.field_vaccination_opens
     - node.type.vaccinations
@@ -39,7 +40,7 @@ content:
     third_party_settings: {  }
   field_old_calendar:
     type: boolean_checkbox
-    weight: 26
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -64,6 +65,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_related_articles_vacci:
+    type: entity_reference_autocomplete
+    weight: 12
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 2
@@ -73,7 +84,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -128,7 +139,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.vaccinations.default.yml
+++ b/config/sync/core.entity_view_display.node.vaccinations.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.vaccinations.field_pinned_article
     - field.field.node.vaccinations.field_pinned_video_article
     - field.field.node.vaccinations.field_pre_populated
+    - field.field.node.vaccinations.field_related_articles_vacci
     - field.field.node.vaccinations.field_vaccination_closes
     - field.field.node.vaccinations.field_vaccination_opens
     - node.type.vaccinations
@@ -97,6 +98,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 108
+    region: content
+  field_related_articles_vacci:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 111
     region: content
   field_vaccination_closes:
     type: number_integer

--- a/config/sync/core.entity_view_display.node.vaccinations.full.yml
+++ b/config/sync/core.entity_view_display.node.vaccinations.full.yml
@@ -1,9 +1,9 @@
-uuid: c5885c2b-fe29-4a50-87cf-3fc59164ba99
+uuid: b2495ceb-6903-4647-80ff-4d287b699298
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.full
     - field.field.node.vaccinations.body
     - field.field.node.vaccinations.feeds_item
     - field.field.node.vaccinations.field_growth_period
@@ -19,21 +19,12 @@ dependencies:
     - field.field.node.vaccinations.field_vaccination_opens
     - node.type.vaccinations
   module:
-    - text
     - user
-id: node.vaccinations.teaser
+id: node.vaccinations.full
 targetEntityType: node
 bundle: vaccinations
-mode: teaser
+mode: full
 content:
-  body:
-    type: text_summary_or_trimmed
-    label: hidden
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    weight: 101
-    region: content
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
@@ -45,6 +36,7 @@ content:
     weight: 100
     region: content
 hidden:
+  body: true
   feeds_item: true
   field_growth_period: true
   field_licensed_content: true

--- a/config/sync/field.field.node.vaccinations.field_related_articles_vacci.yml
+++ b/config/sync/field.field.node.vaccinations.field_related_articles_vacci.yml
@@ -1,0 +1,34 @@
+uuid: 6b3a0ece-c64f-4cac-ac44-ebc26f5ac842
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_articles_vacci
+    - node.type.article
+    - node.type.vaccinations
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.vaccinations.field_related_articles_vacci
+field_name: field_related_articles_vacci
+entity_type: node
+bundle: vaccinations
+label: 'Related Articles'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_related_articles_vacci.yml
+++ b/config/sync/field.storage.node.field_related_articles_vacci.yml
@@ -1,0 +1,19 @@
+uuid: 8881a45b-c0cb-42e7-be9f-563121d21f05
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_related_articles_vacci
+field_name: field_related_articles_vacci
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.storage.node.field_premature_content
     - field.storage.node.field_related_activities
     - field.storage.node.field_related_articles
+    - field.storage.node.field_related_articles_vacci
     - field.storage.node.field_related_video_articles
     - field.storage.node.field_seasons
     - field.storage.node.field_standard_deviation
@@ -25375,6 +25376,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_related_articles_vacci:
+          id: field_related_articles_vacci
+          table: node__field_related_articles_vacci
+          field: field_related_articles_vacci
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         created:
           id: created
           table: node_field_data
@@ -25722,6 +25785,9 @@ display:
             field_pinned_video_article:
               alias: pinned_video_article
               raw_output: false
+            field_related_articles_vacci:
+              alias: related_articles
+              raw_output: false
             created:
               alias: created_at
               raw_output: false
@@ -25756,3 +25822,4 @@ display:
         - 'config:field.storage.node.field_old_calendar'
         - 'config:field.storage.node.field_pinned_article'
         - 'config:field.storage.node.field_pinned_video_article'
+        - 'config:field.storage.node.field_related_articles_vacci'

--- a/config/sync/views.view.bebbo_v2_apis.yml
+++ b/config/sync/views.view.bebbo_v2_apis.yml
@@ -9,12 +9,18 @@ dependencies:
     - field.storage.node.field_featured_image_1
     - field.storage.node.field_featured_image_2
     - field.storage.node.field_fun_fact
+    - field.storage.node.field_growth_period
     - field.storage.node.field_message
+    - field.storage.node.field_old_calendar
     - field.storage.node.field_parental_week
+    - field.storage.node.field_pinned_article
+    - field.storage.node.field_pinned_video_article
     - field.storage.node.field_related_articles
+    - field.storage.node.field_related_articles_vacci
     - field.storage.node.field_related_games
     - node.type.guide
     - node.type.pregnancy_weekly_overview
+    - node.type.vaccinations
   module:
     - custom_serialization
     - node
@@ -23,7 +29,6 @@ dependencies:
     - serialization
     - text
     - user
-    - views_data_export
 id: bebbo_v2_apis
 label: 'Bebbo v2 APIs'
 module: views
@@ -934,11 +939,11 @@ display:
         - 'config:field.storage.node.field_related_articles'
   guide_rest_export:
     id: guide_rest_export
-    display_title: 'Guide Rest Export'
+    display_title: 'Guide API'
     display_plugin: rest_export
     position: 2
     display_options:
-      title: 'Guide Rest Export'
+      title: 'Guide API'
       fields:
         nid:
           id: nid
@@ -1590,13 +1595,859 @@ display:
         - 'config:field.storage.node.field_message'
         - 'config:field.storage.node.field_related_articles'
         - 'config:field.storage.node.field_related_games'
+  vaccination_rest_export:
+    id: vaccination_rest_export
+    display_title: 'Vaccinations API'
+    display_plugin: rest_export
+    position: 3
+    display_options:
+      title: 'Vaccinations API'
+      fields:
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_growth_period:
+          id: field_growth_period
+          table: node__field_growth_period
+          field: field_growth_period
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_pinned_article:
+          id: field_pinned_article
+          table: node__field_pinned_article
+          field: field_pinned_article
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 7
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_pinned_video_article:
+          id: field_pinned_video_article
+          table: node__field_pinned_video_article
+          field: field_pinned_video_article
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_related_articles_vacci:
+          id: field_related_articles_vacci
+          table: node__field_related_articles_vacci
+          field: field_related_articles_vacci
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_old_calendar:
+          id: field_old_calendar
+          table: node__field_old_calendar
+          field: field_old_calendar
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: on-off
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            vaccinations: vaccinations
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: bebbo_serializer
+        options:
+          uses_fields: false
+          formats:
+            json: json
+      row:
+        type: data_field
+        options:
+          field_options:
+            uuid:
+              alias: uuid
+              raw_output: false
+            nid:
+              alias: id
+              raw_output: false
+            type:
+              alias: type
+              raw_output: false
+            title:
+              alias: title
+              raw_output: false
+            field_growth_period:
+              alias: growth_period
+              raw_output: false
+            field_pinned_article:
+              alias: pinned_article
+              raw_output: false
+            field_pinned_video_article:
+              alias: pinned_video_article
+              raw_output: false
+            field_related_articles_vacci:
+              alias: related_articles
+              raw_output: false
+            created:
+              alias: created_at
+              raw_output: false
+            changed:
+              alias: updated_at
+              raw_output: false
+            field_old_calendar:
+              alias: old_calendar
+              raw_output: false
+      defaults:
+        title: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: v2/api/vaccinations/%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_growth_period'
+        - 'config:field.storage.node.field_old_calendar'
+        - 'config:field.storage.node.field_pinned_article'
+        - 'config:field.storage.node.field_pinned_video_article'
+        - 'config:field.storage.node.field_related_articles_vacci'
   weekly_overview_export:
     id: weekly_overview_export
-    display_title: 'Pregnancy Weekly Overview'
+    display_title: 'Pregnancy Weekly Overview API'
     display_plugin: rest_export
     position: 1
     display_options:
-      title: 'Pregnancy Weekly Overview'
+      title: 'Pregnancy Weekly Overview API'
       fields:
         nid:
           id: nid
@@ -2331,25 +3182,10 @@ display:
         options:
           offset: 0
       style:
-        type: data_export
+        type: bebbo_serializer
         options:
           formats:
             json: json
-          csv_settings:
-            delimiter: ','
-            enclosure: '"'
-            escape_char: \
-            strip_tags: true
-            trim: true
-            encoding: utf8
-            utf8_bom: '0'
-            use_serializer_encode_only: false
-            output_header: true
-          xml_settings:
-            encoding: UTF-8
-            root_node_name: response
-            item_node_name: item
-            format_output: false
       row:
         type: data_field
         options:

--- a/docroot/modules/custom/custom_serialization/src/Plugin/views/style/BebboSerializer.php
+++ b/docroot/modules/custom/custom_serialization/src/Plugin/views/style/BebboSerializer.php
@@ -272,21 +272,18 @@ class BebboSerializer extends Serializer {
    */
   private function transformRows(string $displayId, array $rows): array {
     return match ($displayId) {
-      'weekly_overview_export' => $this->transformPregnancyWeekly($rows),
-      'guide_rest_export'      => $this->transformGuide($rows),
-      // Add new display cases here for each new REST export display.
+      'weekly_overview_export'  => $this->transformPregnancyWeekly($rows),
+      'guide_rest_export'       => $this->transformGuide($rows),
+      'vaccination_rest_export' => $this->transformVaccinations($rows),
       default => $rows,
     };
   }
 
   /**
-   * Transforms rows for the pregnancy_weekly_overview view.
+   * Transforms rows for the pregnancy weekly overview display.
    *
-   * - Resolves featured_image_1 / featured_image_2 media IDs to absolute
-   *   WebP URLs via a single batch entity load (no N+1 queries).
-   * - Casts prental_age to int.
-   * - Casts average_height / average_weight to 2-decimal float strings.
-   * - Converts related_articles comma string to a deduplicated int array.
+   * Resolves media fields to WebP URLs, casts numeric fields, and converts
+   * related_articles to a deduplicated int array.
    *
    * @param array $rows
    *   Raw rows from the view.
@@ -299,74 +296,12 @@ class BebboSerializer extends Serializer {
       return $rows;
     }
 
-    $mediaFields = ['featured_image_1', 'featured_image_2'];
+    $this->resolveMediaToWebp($rows, ['featured_image_1', 'featured_image_2']);
 
-    // 1. Collect every media ID across all rows in one pass.
-    $mediaIds = array_unique(array_filter(
-      array_merge(...array_map(
-        fn($row) => array_map(fn($f) => $row[$f] ?? NULL, $mediaFields),
-        $rows
-      )),
-      'is_numeric'
-    ));
-
-    // 2. Batch-load all media entities once → build ID → WebP URL map.
-    // Load image style once (same style used by CustomSerializer).
-    // buildUrl() produces the resized derivative URL; the WebP module then
-    // generates the .webp file alongside it on first request.
-    // Falls back to the raw file URL if the image style is missing.
-    $loadedStyle = $this->entityTypeManager
-      ->getStorage('image_style')
-      ->load('content_1200xh_');
-    $imageStyle = $loadedStyle instanceof ImageStyle ? $loadedStyle : NULL;
-
-    $urlMap = [];
-    if ($mediaIds) {
-      foreach ($this->entityTypeManager->getStorage('media')->loadMultiple($mediaIds) as $media) {
-        if (!$media instanceof MediaInterface) {
-          continue;
-        }
-        $file = $media->get('field_media_image')->entity;
-        if ($file instanceof FileInterface) {
-          $uri = $file->getFileUri();
-          // Build the styled URL (e.g. /styles/content_1200xh_/public/…).
-          // Fallback to raw absolute URL if image style is unavailable.
-          $styledUrl = $imageStyle
-            ? $imageStyle->buildUrl($uri)
-            : $this->fileUrlGenerator->generateAbsoluteString($uri);
-          // Convert jpg/jpeg/png → .webp
-          // (mirrors CustomSerializerHelper::convertToWebp).
-          $urlMap[$media->id()] = preg_replace('/\.(jpg|jpeg|png)(\?.*)?$/i', '.webp$2', $styledUrl) ?? $styledUrl;
-        }
-      }
-    }
-
-    // 3. Apply per-row field transformations.
     foreach ($rows as &$row) {
-      // Media ID → WebP URL. NULL when media is missing or unpublished.
-      foreach ($mediaFields as $field) {
-        $row[$field] = $urlMap[(int) ($row[$field] ?? 0)] ?? NULL;
-      }
-
-      $row['id']             = (int) ($row['id'] ?? 0);
-      $row['prental_age']    = (int) ($row['prental_age'] ?? 0);
-      $row['average_height'] = round((float) ($row['average_height'] ?? 0), 2);
-      $row['average_weight'] = round((float) ($row['average_weight'] ?? 0), 2);
-
-      // raw_output:true on a multi-value entity reference field delivers an
-      // array of target IDs directly. raw_output:false delivers a rendered
-      // comma-separated string of labels. Handle both so the code is robust.
-      $rawArticles = $row['related_articles'] ?? [];
-      if (is_array($rawArticles)) {
-        $articleIds = $rawArticles;
-      }
-      else {
-        $articleIds = array_filter(
-          array_map('trim', explode(',', (string) $rawArticles)),
-          'is_numeric'
-        );
-      }
-      $row['related_articles'] = array_values(array_unique(array_map('intval', $articleIds)));
+      $this->castToInt($row, ['id', 'prental_age']);
+      $this->castToFloat($row, ['average_height', 'average_weight']);
+      $this->toIntArray($row, ['related_articles']);
     }
     unset($row);
 
@@ -374,12 +309,10 @@ class BebboSerializer extends Serializer {
   }
 
   /**
-   * Transforms rows for the guide_rest_export display.
+   * Transforms rows for the guide REST export display.
    *
-   * - Casts id to int.
-   * - Converts child_age, related_articles, related_games to deduplicated
-   *   int arrays. Handles both raw array (raw_output:true) and
-   *   comma-separated string (raw_output:false) from the view row plugin.
+   * Casts id to int and converts multi-value reference fields to int arrays.
+   * Removes related_articles when empty.
    *
    * @param array $rows
    *   Raw rows from the view.
@@ -392,35 +325,183 @@ class BebboSerializer extends Serializer {
       return $rows;
     }
 
-    // Fields that must become deduplicated int arrays.
-    $multiIntFields = ['child_age', 'related_articles', 'related_games'];
-
     foreach ($rows as &$row) {
-      $row['id'] = (int) ($row['id'] ?? 0);
+      $this->castToInt($row, ['id']);
+      $this->toIntArray($row, ['child_age', 'related_articles', 'related_games']);
 
-      foreach ($multiIntFields as $field) {
-        $raw = $row[$field] ?? [];
-        if (is_array($raw)) {
-          $ids = $raw;
-        }
-        else {
-          $ids = array_filter(
-            array_map('trim', explode(',', (string) $raw)),
-            'is_numeric'
-          );
-        }
-        $ids = array_values(array_unique(array_map('intval', $ids)));
-        if ($field === 'related_articles' && empty($ids)) {
-          unset($row[$field]);
-        }
-        else {
-          $row[$field] = $ids;
-        }
+      // Remove related_articles when empty (display-specific rule).
+      if (empty($row['related_articles'])) {
+        unset($row['related_articles']);
       }
     }
     unset($row);
 
     return $rows;
+  }
+
+  /**
+   * Transforms rows for the vaccination REST export display.
+   *
+   * Casts numeric fields to int, converts pinned_article to a deduplicated
+   * int array, and decodes HTML entities in title.
+   *
+   * @param array $rows
+   *   Raw rows from the view.
+   *
+   * @return array
+   *   Transformed rows.
+   */
+  private function transformVaccinations(array $rows): array {
+    if (empty($rows)) {
+      return $rows;
+    }
+
+    foreach ($rows as &$row) {
+      $this->castToInt($row, ['id', 'growth_period', 'pinned_video_article', 'old_calendar', 'pinned_article']);
+      $this->toIntArray($row, ['related_articles']);
+      $this->decodeHtmlEntities($row, ['title']);
+    }
+    unset($row);
+
+    return $rows;
+  }
+
+  /**
+   * Casts the given row fields to integers.
+   *
+   * Missing or empty values default to 0.
+   *
+   * @param array $row
+   *   A single row (passed by reference).
+   * @param array $fields
+   *   Field names to cast.
+   */
+  private function castToInt(array &$row, array $fields): void {
+    foreach ($fields as $field) {
+      $row[$field] = (int) ($row[$field] ?? 0);
+    }
+  }
+
+  /**
+   * Rounds the given row fields to floats with a fixed number of decimals.
+   *
+   * Missing or empty values default to 0.0.
+   *
+   * @param array $row
+   *   A single row (passed by reference).
+   * @param array $fields
+   *   Field names to cast.
+   * @param int $decimals
+   *   Number of decimal places (default 2).
+   */
+  private function castToFloat(array &$row, array $fields, int $decimals = 2): void {
+    foreach ($fields as $field) {
+      $row[$field] = round((float) ($row[$field] ?? 0), $decimals);
+    }
+  }
+
+  /**
+   * Converts row fields to deduplicated integer arrays.
+   *
+   * Handles both raw arrays (raw_output:true) and comma-separated strings
+   * (raw_output:false) from the Views row plugin.
+   *
+   * @param array $row
+   *   A single row (passed by reference).
+   * @param array $fields
+   *   Field names to convert.
+   */
+  private function toIntArray(array &$row, array $fields): void {
+    foreach ($fields as $field) {
+      $raw = $row[$field] ?? [];
+      if (is_array($raw)) {
+        $ids = $raw;
+      }
+      else {
+        $ids = array_filter(
+          array_map('trim', explode(',', (string) $raw)),
+          'is_numeric'
+        );
+      }
+      $row[$field] = array_values(array_unique(array_map('intval', $ids)));
+    }
+  }
+
+  /**
+   * Decodes HTML entities in the given row fields.
+   *
+   * @param array $row
+   *   A single row (passed by reference).
+   * @param array $fields
+   *   Field names to decode.
+   */
+  private function decodeHtmlEntities(array &$row, array $fields): void {
+    foreach ($fields as $field) {
+      if (!empty($row[$field])) {
+        $row[$field] = htmlspecialchars_decode((string) $row[$field], ENT_QUOTES | ENT_HTML5);
+      }
+    }
+  }
+
+  /**
+   * Resolves media ID fields to styled WebP URLs across all rows.
+   *
+   * Batch-collects media IDs, loads entities in a single query, builds
+   * an ID-to-URL map with the content_1200xh_ image style, and replaces
+   * each media ID with the corresponding absolute WebP URL.
+   *
+   * @param array $rows
+   *   All rows (passed by reference).
+   * @param array $fields
+   *   Field names containing media IDs.
+   */
+  private function resolveMediaToWebp(array &$rows, array $fields): void {
+    // 1. Collect every media ID across all rows in one pass.
+    $mediaIds = array_unique(array_filter(
+      array_merge(...array_map(
+        fn($row) => array_map(fn($f) => $row[$f] ?? NULL, $fields),
+        $rows
+      )),
+      'is_numeric'
+    ));
+
+    if (empty($mediaIds)) {
+      return;
+    }
+
+    // 2. Load image style once; fallback to raw URL if missing.
+    $loadedStyle = $this->entityTypeManager
+      ->getStorage('image_style')
+      ->load('content_1200xh_');
+    $imageStyle = $loadedStyle instanceof ImageStyle ? $loadedStyle : NULL;
+
+    // 3. Batch-load media entities and build ID → WebP URL map.
+    $urlMap = [];
+    foreach ($this->entityTypeManager->getStorage('media')->loadMultiple($mediaIds) as $media) {
+      if (!$media instanceof MediaInterface) {
+        continue;
+      }
+      $file = $media->get('field_media_image')->entity;
+      if ($file instanceof FileInterface) {
+        $uri = $file->getFileUri();
+        $styledUrl = $imageStyle
+          ? $imageStyle->buildUrl($uri)
+          : $this->fileUrlGenerator->generateAbsoluteString($uri);
+        $urlMap[$media->id()] = preg_replace(
+          '/\.(jpg|jpeg|png)(\?.*)?$/i',
+          '.webp$2',
+          $styledUrl
+        ) ?? $styledUrl;
+      }
+    }
+
+    // 4. Replace media IDs with URLs in each row.
+    foreach ($rows as &$row) {
+      foreach ($fields as $field) {
+        $row[$field] = $urlMap[(int) ($row[$field] ?? 0)] ?? NULL;
+      }
+    }
+    unset($row);
   }
 
   /**

--- a/docroot/modules/custom/custom_serialization/src/Plugin/views/style/CustomSerializer.php
+++ b/docroot/modules/custom/custom_serialization/src/Plugin/views/style/CustomSerializer.php
@@ -185,8 +185,8 @@ class CustomSerializer extends Serializer {
         "id", "field_type_of_article", "category", "subcategory", "child_gender", "parent_gender", "licensed", "premature",
         "mandatory", "growth_type", "standard_deviation", "boy_video_article", "girl_video_article",
         "growth_period", "activity_category", "equipment", "type_of_support",
-        "make_available_for_mobile", "pinned_article", "pinned_video_article", "chatbot_subcategory",
-        "related_article", "old_calendar",
+        "make_available_for_mobile", "pinned_video_article", "chatbot_subcategory",
+        "related_article", "old_calendar", "pinned_article",
       ];
       $string_to_array_of_int = [
         "related_articles", "keywords", "child_age", "related_activities", "related_video_articles",


### PR DESCRIPTION
## Summary

  - Expose the new multi-value Related Articles field (up to 7 references) in
    the vaccination API response as a deduplicated integer array
  - Both v1 (`/api/vaccinations/%`) and v2 (`/v2/api/vaccinations/%`) endpoints
    return the new `related_articles` key

  ## Changes

  - **CustomSerializer.php**: `related_articles` processed via existing
    `$array_of_multiple_values` and `$string_to_array_of_int` lists
  - **BebboSerializer.php**: `related_articles` added to `toIntArray()` in
    `transformVaccinations()`