### PR TITLE
Fix General pointer issues.

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_body_rendered
     - field.field.node.page.field_embedded_images
     - field.field.node.page.field_licensed_content
     - field.field.node.page.field_mandatory_content
@@ -132,6 +133,7 @@ content:
     third_party_settings: {  }
 hidden:
   feeds_item: true
+  field_body_rendered: true
   field_embedded_images: true
   field_licensed_content: true
   layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_body_rendered
     - field.field.node.page.field_embedded_images
     - field.field.node.page.field_licensed_content
     - field.field.node.page.field_mandatory_content
@@ -130,6 +131,21 @@ third_party_settings:
                 third_party_settings: {  }
             weight: 6
             additional: {  }
+          ba709254-a679-4408-b9d1-3270589610a3:
+            uuid: ba709254-a679-4408-b9d1-3270589610a3
+            region: content
+            configuration:
+              id: 'field_block:node:page:field_body_rendered'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: text_default
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+            weight: 7
+            additional: {  }
         third_party_settings: {  }
 _core:
   default_config_hash: g1S3_GLaxq4l3I9RIca5Mlz02MxI2KmOquZpHw59akM
@@ -149,6 +165,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_body_rendered:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 12
     region: content
   field_embedded_images:
     type: string

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.page.body
+    - field.field.node.page.field_body_rendered
     - field.field.node.page.field_embedded_images
     - field.field.node.page.field_licensed_content
     - field.field.node.page.field_mandatory_content
@@ -145,6 +146,7 @@ content:
     weight: 101
     region: content
 hidden:
+  field_body_rendered: true
   field_embedded_images: true
   field_meta_tags: true
   field_pre_populated: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
+    - field.field.node.page.field_body_rendered
     - field.field.node.page.field_embedded_images
     - field.field.node.page.field_licensed_content
     - field.field.node.page.field_mandatory_content
@@ -39,6 +40,7 @@ content:
     weight: 101
     region: content
 hidden:
+  field_body_rendered: true
   field_embedded_images: true
   field_licensed_content: true
   field_mandatory_content: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,9 +20,9 @@ module:
   config_ignore: 0
   config_split: 0
   config_translation: 0
+  consumers: 0
   content_moderation: 0
   content_moderation_notifications: 0
-  consumers: 0
   contextual: 0
   csv_serialization: 0
   custom_article: 0

--- a/config/sync/field.field.node.page.field_body_rendered.yml
+++ b/config/sync/field.field.node.page.field_body_rendered.yml
@@ -1,0 +1,28 @@
+uuid: 1bf50ec3-61b3-4a86-80d0-daf88b7f5748
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_body_rendered
+    - filter.format.full_html
+    - node.type.page
+  module:
+    - text
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.page.field_body_rendered
+field_name: field_body_rendered
+entity_type: node
+bundle: page
+label: 'Body Rendered'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - full_html
+field_type: text_long

--- a/config/sync/views.view.bebbo_v2_apis.yml
+++ b/config/sync/views.view.bebbo_v2_apis.yml
@@ -4986,10 +4986,10 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        body:
-          id: body
-          table: node__body
-          field: body
+        field_body_rendered:
+          id: field_body_rendered
+          table: node__field_body_rendered
+          field: field_body_rendered
           relationship: none
           group_type: group
           admin_label: ''
@@ -5263,7 +5263,7 @@ display:
             changed:
               alias: updated_at
               raw_output: false
-            body:
+            field_body_rendered:
               alias: body
               raw_output: false
             field_mandatory_content:
@@ -5292,7 +5292,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_body_rendered'
         - 'config:field.storage.node.field_embedded_images'
         - 'config:field.storage.node.field_mandatory_content'
   child_dev_boy_rest_export:
@@ -12025,6 +12025,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_child_s_age:
+          id: field_child_s_age
+          table: node__field_child_s_age
+          field: field_child_s_age
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: none
         options:
@@ -12202,6 +12264,9 @@ display:
             field_mandatory_content:
               alias: mandatory
               raw_output: false
+            field_child_s_age:
+              alias: child_age
+              raw_output: false
       defaults:
         title: false
         relationships: false
@@ -12226,6 +12291,7 @@ display:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_answer_part_2'
         - 'config:field.storage.node.field_chatbot_subcategory'
+        - 'config:field.storage.node.field_child_s_age'
         - 'config:field.storage.node.field_mandatory_content'
         - 'config:field.storage.node.field_pinned_article'
   guide_rest_export:

--- a/config/sync/views.view.country_listing.yml
+++ b/config/sync/views.view.country_listing.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.group.field_2_0_branding
     - field.storage.group.field_app_name
     - field.storage.group.field_content_toggle
     - field.storage.group.field_country_email
@@ -527,7 +528,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: list_default
+          type: list_key
           settings: {  }
           group_column: value
           group_columns: {  }
@@ -747,7 +748,7 @@ display:
         - 'config:field.storage.group.field_unicef_logo'
   country_listing_export:
     id: country_listing_export
-    display_title: 'Country listing API'
+    display_title: 'V2 Country listing API'
     display_plugin: rest_export
     position: 2
     display_options:
@@ -1131,6 +1132,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_2_0_branding:
+          id: field_2_0_branding
+          table: group__field_2_0_branding
+          field: field_2_0_branding
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         field_language:
           id: field_language
           table: group__field_language
@@ -1473,6 +1536,58 @@ display:
           view: media_details
           display: block_1
           arguments: '{{ raw_fields.field_unicef_logo }}'
+        view_3:
+          id: view_3
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: view
+          label: '2.0 Branding'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view: media_details
+          display: block_1
+          arguments: '{{ raw_fields.field_2_0_branding }}'
       pager:
         type: none
         options:
@@ -1558,6 +1673,9 @@ display:
             field_country_email:
               alias: country_email
               raw_output: false
+            field_2_0_branding:
+              alias: ''
+              raw_output: false
             field_language:
               alias: langcode
               raw_output: true
@@ -1575,6 +1693,9 @@ display:
               raw_output: false
             view_2:
               alias: unicef_logo
+              raw_output: false
+            view_3:
+              alias: field_2_0_branding
               raw_output: false
       query:
         type: views_query
@@ -1603,6 +1724,7 @@ display:
         - url
         - user.permissions
       tags:
+        - 'config:field.storage.group.field_2_0_branding'
         - 'config:field.storage.group.field_app_name'
         - 'config:field.storage.group.field_content_toggle'
         - 'config:field.storage.group.field_country_email'
@@ -1612,7 +1734,7 @@ display:
         - 'config:field.storage.group.field_unicef_logo'
   rest_export_1:
     id: rest_export_1
-    display_title: 'REST export'
+    display_title: 'V1 Country listing API'
     display_plugin: rest_export
     position: 1
     display_options:
@@ -1656,6 +1778,7 @@ display:
             field_app_name:
               alias: app_name
               raw_output: false
+      display_description: ''
       display_extenders: {  }
       path: api/country-groups/%
     cache_metadata:

--- a/config/sync/views.view.media_details.yml
+++ b/config/sync/views.view.media_details.yml
@@ -633,6 +633,7 @@ display:
       display_description: ''
       rendering_language: '***LANGUAGE_language_interface***'
       display_extenders: {  }
+      block_description: 'Media Image Details API'
     cache_metadata:
       max-age: -1
       contexts:
@@ -965,6 +966,7 @@ display:
       display_description: ''
       rendering_language: '***LANGUAGE_language_interface***'
       display_extenders: {  }
+      block_description: 'Media Remote Video Details API'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1059,7 +1061,7 @@ display:
           label: Thumbnail
           exclude: false
           alter:
-            alter_text: false
+            alter_text: true
             text: "{{ thumbnail__target_id|replace({'.jpg': '.webp', '.jpeg': '.webp', '.png': '.webp'}) }}"
             make_link: false
             path: ''
@@ -1254,6 +1256,7 @@ display:
       display_description: ''
       rendering_language: '***LANGUAGE_language_interface***'
       display_extenders: {  }
+      block_description: 'Media Remote Video Thumb API'
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
+++ b/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
@@ -525,6 +525,7 @@ class BebboSerializer extends Serializer {
     foreach ($rows as &$row) {
       $this->castToInt($row, ['id', 'chatbot_subcategory', 'related_article', 'mandatory']);
       $this->decodeHtmlEntities($row, ['question']);
+      $this->toIntArray($row, ['child_age']);
     }
     unset($row);
 
@@ -1630,6 +1631,7 @@ class BebboSerializer extends Serializer {
       'country_national_partner',
       'country_sponsor_logo',
       'unicef_logo',
+      'field_2_0_branding',
     ];
     foreach ($rows as &$row) {
       foreach ($mediaKeys as $key) {
@@ -2250,7 +2252,7 @@ class BebboSerializer extends Serializer {
   private function castToFloat(array &$row, array $fields, int $decimals = 2): void {
     foreach ($fields as $field) {
       if (array_key_exists($field, $row)) {
-        $row[$field] = round((float) ($row[$field] ?? 0), $decimals);
+        $row[$field] = (float) number_format((float) ($row[$field] ?? 0), $decimals, '.', '');
       }
     }
   }


### PR DESCRIPTION
## Summary of changes

- **WebP image not visible in video thumbnail** — Fixed the view to resolve the image rendering issue.
- **FAQs v2 API: added `child_age` field** — The `child_age` field is now included in the v2 FAQs API response.
- **App new v2 group icons to country API** — New group icons are now exposed in the v2 country-groups API.
- **v1 country API `content_toggle` key format fix** — The v1 `content_toggle` field was outputting human-readable labels (e.g. "Child's Growth", "Health Check-up") instead of machine names (`childs_growth`, `health_check_up`). Root cause: the v1 `CustomSerializer` passes through the Views-rendered output using the `list_default` formatter (`raw_output: false`), which renders labels. The v2 `BebboSerializer` correctly overrides this by loading raw entity values directly via `$group->getUntranslated()->get('field_content_toggle')->getValue()`. Applied the same entity-level override in v1 for consistency.
- **Body field in basic-page** — This is a content change; the content team will handle it.
- **Weekly overview height/weight decimal points** — Needs investigation into decimal precision handling. 