### PR TITLE
Content analytics sync and display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/ai_provider_openai": "^1.2",
         "drupal/ai_translate": "^1.3",
         "drupal/allowed_languages": "^2.0",
+        "drupal/better_exposed_filters": "^7.1",
         "drupal/blazy": "^2.22",
         "drupal/ckeditor_media_embed": "^1.11",
         "drupal/color": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb6ae6f9835b5ce86cde67500dee94d4",
+    "content-hash": "ef7a4667a508cb4139dea5e8a1950719",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -2790,6 +2790,80 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/allowed_languages",
                 "issues": "https://www.drupal.org/project/issues/allowed_languages"
+            }
+        },
+        {
+            "name": "drupal/better_exposed_filters",
+            "version": "7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/better_exposed_filters.git",
+                "reference": "7.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/better_exposed_filters-7.1.1.zip",
+                "reference": "7.1.1",
+                "shasum": "e22a4afccf011a583e2ae6297d34f7d344552469"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "drupal/nouislider_js": "^15.8.1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "7.1.1",
+                    "datestamp": "1763681621",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Keran",
+                    "homepage": "https://www.drupal.org/u/mikeker"
+                },
+                {
+                    "name": "Martin Keereman",
+                    "homepage": "https://www.drupal.org/u/etroid"
+                },
+                {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/u/neslee-canil-pinto"
+                },
+                {
+                    "name": "mikeker",
+                    "homepage": "https://www.drupal.org/user/192273"
+                },
+                {
+                    "name": "neslee canil pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
+                },
+                {
+                    "name": "podarok",
+                    "homepage": "https://www.drupal.org/user/116002"
+                },
+                {
+                    "name": "rlhawk",
+                    "homepage": "https://www.drupal.org/user/352283"
+                },
+                {
+                    "name": "smustgrave",
+                    "homepage": "https://www.drupal.org/user/3252890"
+                }
+            ],
+            "description": "Replaces the Views default single- or multi-select boxes with more advanced options.",
+            "homepage": "https://www.drupal.org/project/better_exposed_filters",
+            "support": {
+                "source": "https://git.drupalcode.org/project/better_exposed_filters",
+                "issues": "https://www.drupal.org/project/issues/better_exposed_filters"
             }
         },
         {
@@ -6732,6 +6806,35 @@
                 "source": "https://cgit.drupalcode.org/mobile_app_links",
                 "issues": "https://drupal.org/project/issues/mobile_app_links"
             }
+        },
+        {
+            "name": "drupal/nouislider_js",
+            "version": "15.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/nouislider_js.git",
+                "reference": "b5610d5842784581e4c766cd1c3852ca0b355ed5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fnouislider_js/repository/archive.zip?sha=b5610d5842784581e4c766cd1c3852ca0b355ed5",
+                "reference": "b5610d5842784581e4c766cd1c3852ca0b355ed5",
+                "shasum": ""
+            },
+            "type": "drupal-library",
+            "extra": {
+                "installer-name": "nouislider"
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT License"
+            ],
+            "description": "Mirror of the noUiSlider javascript library tagged as a Drupal library.",
+            "homepage": "https://github.com/leongersen/noUiSlider",
+            "support": {
+                "source": "https://git.drupalcode.org/project/nouislider_js/-/tree/15.8.0"
+            },
+            "time": "2025-01-03T10:53:20+00:00"
         },
         {
             "name": "drupal/paragraphs",

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -7,6 +7,7 @@ ignored_config_entities:
   - google_analytics.settings
   - mobile_app_links.android_packages
   - mobile_app_links.ios
+  - pb_content_analytics.settings
   - pb_custom_form.landing_pages
   - pb_custom_form.language_redirects
   - pb_custom_form.mobile_app_share_link_form

--- a/config/sync/core.entity_form_display.node.activities.default.yml
+++ b/config/sync/core.entity_form_display.node.activities.default.yml
@@ -4,15 +4,19 @@ status: true
 dependencies:
   config:
     - field.field.node.activities.body
+    - field.field.node.activities.feeds_item
     - field.field.node.activities.field_activity_category
+    - field.field.node.activities.field_analytics_updated
     - field.field.node.activities.field_body_rendered
     - field.field.node.activities.field_child_age
     - field.field.node.activities.field_cover_image
     - field.field.node.activities.field_embedded_images
     - field.field.node.activities.field_equipment
     - field.field.node.activities.field_licensed_content
+    - field.field.node.activities.field_like_count
     - field.field.node.activities.field_mandatory_content
     - field.field.node.activities.field_pre_populated
+    - field.field.node.activities.field_read_count
     - field.field.node.activities.field_related_articles
     - field.field.node.activities.field_type_of_support
     - node.type.activities
@@ -49,6 +53,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_analytics_updated:
+    type: datetime_timestamp
+    weight: 29
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_child_age:
     type: options_select
     weight: 11
@@ -61,6 +71,13 @@ content:
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  field_like_count:
+    type: number
+    weight: 27
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_mandatory_content:
     type: boolean_checkbox
@@ -75,6 +92,13 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_read_count:
+    type: number
+    weight: 28
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_related_articles:
     type: entity_reference_autocomplete
@@ -161,6 +185,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  feeds_item: true
   field_activity_child_age: true
   field_body_rendered: true
   field_embedded_images: true

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - field.field.node.article.body
+    - field.field.node.article.feeds_item
+    - field.field.node.article.field_analytics_updated
     - field.field.node.article.field_australian_article
     - field.field.node.article.field_body_rendered
     - field.field.node.article.field_child_age
@@ -15,11 +17,13 @@ dependencies:
     - field.field.node.article.field_generic_content
     - field.field.node.article.field_keywords
     - field.field.node.article.field_licensed_content
+    - field.field.node.article.field_like_count
     - field.field.node.article.field_mandatory_content
     - field.field.node.article.field_meta_keywords
     - field.field.node.article.field_parent_gender
     - field.field.node.article.field_pre_populated
     - field.field.node.article.field_premature_content
+    - field.field.node.article.field_read_count
     - field.field.node.article.field_references_and_comments
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_related_video_articles
@@ -53,6 +57,12 @@ content:
   created:
     type: datetime_timestamp
     weight: 22
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_analytics_updated:
+    type: datetime_timestamp
+    weight: 29
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -112,6 +122,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_like_count:
+    type: number
+    weight: 27
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
   field_mandatory_content:
     type: boolean_checkbox
     weight: 20
@@ -146,6 +163,13 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_read_count:
+    type: number
+    weight: 28
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_references_and_comments:
     type: text_textarea
@@ -262,6 +286,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  feeds_item: true
   field_body_rendered: true
   field_embedded_images: true
   field_generic_content: true

--- a/config/sync/core.entity_form_display.node.course.default.yml
+++ b/config/sync/core.entity_form_display.node.course.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.course.feeds_item
+    - field.field.node.course.field_analytics_updated
     - field.field.node.course.field_certificate
     - field.field.node.course.field_child_age
     - field.field.node.course.field_course_category
@@ -14,10 +16,12 @@ dependencies:
     - field.field.node.course.field_feedback_question
     - field.field.node.course.field_feedback_required
     - field.field.node.course.field_final_assessment
+    - field.field.node.course.field_like_count
     - field.field.node.course.field_module
     - field.field.node.course.field_module_numbering_style
     - field.field.node.course.field_modules_unlock
     - field.field.node.course.field_number_of_modules
+    - field.field.node.course.field_read_count
     - field.field.node.course.field_reference
     - field.field.node.course.field_target_audience
     - node.type.course
@@ -36,6 +40,12 @@ content:
   created:
     type: datetime_timestamp
     weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_analytics_updated:
+    type: datetime_timestamp
+    weight: 29
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -123,6 +133,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_like_count:
+    type: number
+    weight: 27
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
   field_module:
     type: paragraphs
     weight: 130
@@ -157,6 +174,13 @@ content:
   field_number_of_modules:
     type: number
     weight: 129
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_read_count:
+    type: number
+    weight: 28
     region: content
     settings:
       placeholder: ''
@@ -247,4 +271,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  feeds_item: true

--- a/config/sync/core.entity_form_display.node.video_article.default.yml
+++ b/config/sync/core.entity_form_display.node.video_article.default.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - field.field.node.video_article.body
+    - field.field.node.video_article.feeds_item
+    - field.field.node.video_article.field_analytics_updated
     - field.field.node.video_article.field_australian_article
     - field.field.node.video_article.field_body_rendered
     - field.field.node.video_article.field_child_age
@@ -14,11 +16,13 @@ dependencies:
     - field.field.node.video_article.field_generic_content
     - field.field.node.video_article.field_keywords
     - field.field.node.video_article.field_licensed_content
+    - field.field.node.video_article.field_like_count
     - field.field.node.video_article.field_mandatory_content
     - field.field.node.video_article.field_meta_keywords
     - field.field.node.video_article.field_parent_gender
     - field.field.node.video_article.field_pre_populated
     - field.field.node.video_article.field_premature_content
+    - field.field.node.video_article.field_read_count
     - field.field.node.video_article.field_references_and_comments
     - field.field.node.video_article.field_related_articles
     - field.field.node.video_article.field_related_video_articles
@@ -49,6 +53,12 @@ content:
   created:
     type: datetime_timestamp
     weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_analytics_updated:
+    type: datetime_timestamp
+    weight: 29
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -101,6 +111,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_like_count:
+    type: number
+    weight: 27
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
   field_mandatory_content:
     type: boolean_checkbox
     weight: 17
@@ -128,6 +145,13 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_read_count:
+    type: number
+    weight: 28
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_references_and_comments:
     type: text_textarea
@@ -232,6 +256,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  feeds_item: true
   field_body_rendered: true
   field_embedded_images: true
   field_generic_content: true

--- a/config/sync/core.entity_view_display.node.activities.default.yml
+++ b/config/sync/core.entity_view_display.node.activities.default.yml
@@ -4,15 +4,19 @@ status: true
 dependencies:
   config:
     - field.field.node.activities.body
+    - field.field.node.activities.feeds_item
     - field.field.node.activities.field_activity_category
+    - field.field.node.activities.field_analytics_updated
     - field.field.node.activities.field_body_rendered
     - field.field.node.activities.field_child_age
     - field.field.node.activities.field_cover_image
     - field.field.node.activities.field_embedded_images
     - field.field.node.activities.field_equipment
     - field.field.node.activities.field_licensed_content
+    - field.field.node.activities.field_like_count
     - field.field.node.activities.field_mandatory_content
     - field.field.node.activities.field_pre_populated
+    - field.field.node.activities.field_read_count
     - field.field.node.activities.field_related_articles
     - field.field.node.activities.field_type_of_support
     - node.type.activities
@@ -43,6 +47,25 @@ content:
       link: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_analytics_updated:
+    type: timestamp
+    label: above
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+      tooltip:
+        date_format: long
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings: {  }
+    weight: 119
     region: content
   field_body_rendered:
     type: text_default
@@ -96,6 +119,15 @@ content:
     third_party_settings: {  }
     weight: 10
     region: content
+  field_like_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 117
+    region: content
   field_mandatory_content:
     type: boolean
     label: above
@@ -105,6 +137,15 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_read_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 118
     region: content
   field_related_articles:
     type: entity_reference_label
@@ -128,6 +169,7 @@ content:
     weight: 1
     region: content
 hidden:
+  feeds_item: true
   field_activity_child_age: true
   field_pre_populated: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.activities.full.yml
+++ b/config/sync/core.entity_view_display.node.activities.full.yml
@@ -5,15 +5,19 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.activities.body
+    - field.field.node.activities.feeds_item
     - field.field.node.activities.field_activity_category
+    - field.field.node.activities.field_analytics_updated
     - field.field.node.activities.field_body_rendered
     - field.field.node.activities.field_child_age
     - field.field.node.activities.field_cover_image
     - field.field.node.activities.field_embedded_images
     - field.field.node.activities.field_equipment
     - field.field.node.activities.field_licensed_content
+    - field.field.node.activities.field_like_count
     - field.field.node.activities.field_mandatory_content
     - field.field.node.activities.field_pre_populated
+    - field.field.node.activities.field_read_count
     - field.field.node.activities.field_related_articles
     - field.field.node.activities.field_type_of_support
     - node.type.activities
@@ -106,9 +110,13 @@ content:
     weight: 100
     region: content
 hidden:
+  feeds_item: true
   field_activity_child_age: true
+  field_analytics_updated: true
   field_body_rendered: true
   field_child_age: true
   field_embedded_images: true
+  field_like_count: true
   field_pre_populated: true
+  field_read_count: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.activities.teaser.yml
+++ b/config/sync/core.entity_view_display.node.activities.teaser.yml
@@ -5,15 +5,19 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.activities.body
+    - field.field.node.activities.feeds_item
     - field.field.node.activities.field_activity_category
+    - field.field.node.activities.field_analytics_updated
     - field.field.node.activities.field_body_rendered
     - field.field.node.activities.field_child_age
     - field.field.node.activities.field_cover_image
     - field.field.node.activities.field_embedded_images
     - field.field.node.activities.field_equipment
     - field.field.node.activities.field_licensed_content
+    - field.field.node.activities.field_like_count
     - field.field.node.activities.field_mandatory_content
     - field.field.node.activities.field_pre_populated
+    - field.field.node.activities.field_read_count
     - field.field.node.activities.field_related_articles
     - field.field.node.activities.field_type_of_support
     - node.type.activities
@@ -44,16 +48,20 @@ content:
     weight: 100
     region: content
 hidden:
+  feeds_item: true
   field_activity_category: true
   field_activity_child_age: true
+  field_analytics_updated: true
   field_body_rendered: true
   field_child_age: true
   field_cover_image: true
   field_embedded_images: true
   field_equipment: true
   field_licensed_content: true
+  field_like_count: true
   field_mandatory_content: true
   field_pre_populated: true
+  field_read_count: true
   field_related_articles: true
   field_type_of_support: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - field.field.node.article.body
+    - field.field.node.article.feeds_item
+    - field.field.node.article.field_analytics_updated
     - field.field.node.article.field_australian_article
     - field.field.node.article.field_body_rendered
     - field.field.node.article.field_child_age
@@ -15,11 +17,13 @@ dependencies:
     - field.field.node.article.field_generic_content
     - field.field.node.article.field_keywords
     - field.field.node.article.field_licensed_content
+    - field.field.node.article.field_like_count
     - field.field.node.article.field_mandatory_content
     - field.field.node.article.field_meta_keywords
     - field.field.node.article.field_parent_gender
     - field.field.node.article.field_pre_populated
     - field.field.node.article.field_premature_content
+    - field.field.node.article.field_read_count
     - field.field.node.article.field_references_and_comments
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_related_video_articles
@@ -48,6 +52,25 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_analytics_updated:
+    type: timestamp
+    label: above
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+      tooltip:
+        date_format: long
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings: {  }
+    weight: 119
     region: content
   field_australian_article:
     type: boolean
@@ -130,6 +153,15 @@ content:
     third_party_settings: {  }
     weight: 16
     region: content
+  field_like_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 117
+    region: content
   field_mandatory_content:
     type: boolean
     label: above
@@ -164,6 +196,15 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 17
+    region: content
+  field_read_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 118
     region: content
   field_references_and_comments:
     type: text_default
@@ -218,6 +259,7 @@ content:
     weight: 2
     region: content
 hidden:
+  feeds_item: true
   field_body_rendered: true
   field_embedded_images: true
   field_pre_populated: true

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -5,20 +5,26 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.article.body
+    - field.field.node.article.feeds_item
+    - field.field.node.article.field_analytics_updated
     - field.field.node.article.field_australian_article
+    - field.field.node.article.field_body_rendered
     - field.field.node.article.field_child_age
     - field.field.node.article.field_child_gender
     - field.field.node.article.field_content_category
     - field.field.node.article.field_cover_image
     - field.field.node.article.field_do_not_feature
+    - field.field.node.article.field_embedded_images
     - field.field.node.article.field_generic_content
     - field.field.node.article.field_keywords
     - field.field.node.article.field_licensed_content
+    - field.field.node.article.field_like_count
     - field.field.node.article.field_mandatory_content
     - field.field.node.article.field_meta_keywords
     - field.field.node.article.field_parent_gender
     - field.field.node.article.field_pre_populated
     - field.field.node.article.field_premature_content
+    - field.field.node.article.field_read_count
     - field.field.node.article.field_references_and_comments
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_related_video_articles
@@ -176,11 +182,15 @@ content:
     weight: 2
     region: content
 hidden:
+  feeds_item: true
+  field_analytics_updated: true
   field_body_rendered: true
   field_do_not_feature: true
   field_embedded_images: true
+  field_like_count: true
   field_meta_keywords: true
   field_pre_populated: true
+  field_read_count: true
   field_subcategory: true
   field_target_audience: true
   field_type_of_article: true

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -5,20 +5,26 @@ dependencies:
   config:
     - core.entity_view_mode.node.rss
     - field.field.node.article.body
+    - field.field.node.article.feeds_item
+    - field.field.node.article.field_analytics_updated
     - field.field.node.article.field_australian_article
+    - field.field.node.article.field_body_rendered
     - field.field.node.article.field_child_age
     - field.field.node.article.field_child_gender
     - field.field.node.article.field_content_category
     - field.field.node.article.field_cover_image
     - field.field.node.article.field_do_not_feature
+    - field.field.node.article.field_embedded_images
     - field.field.node.article.field_generic_content
     - field.field.node.article.field_keywords
     - field.field.node.article.field_licensed_content
+    - field.field.node.article.field_like_count
     - field.field.node.article.field_mandatory_content
     - field.field.node.article.field_meta_keywords
     - field.field.node.article.field_parent_gender
     - field.field.node.article.field_pre_populated
     - field.field.node.article.field_premature_content
+    - field.field.node.article.field_read_count
     - field.field.node.article.field_references_and_comments
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_related_video_articles
@@ -45,6 +51,8 @@ content:
     region: content
 hidden:
   body: true
+  feeds_item: true
+  field_analytics_updated: true
   field_australian_article: true
   field_body_rendered: true
   field_child_age: true
@@ -56,11 +64,13 @@ hidden:
   field_generic_content: true
   field_keywords: true
   field_licensed_content: true
+  field_like_count: true
   field_mandatory_content: true
   field_meta_keywords: true
   field_parent_gender: true
   field_pre_populated: true
   field_premature_content: true
+  field_read_count: true
   field_references_and_comments: true
   field_related_articles: true
   field_related_video_articles: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -5,20 +5,26 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.article.body
+    - field.field.node.article.feeds_item
+    - field.field.node.article.field_analytics_updated
     - field.field.node.article.field_australian_article
+    - field.field.node.article.field_body_rendered
     - field.field.node.article.field_child_age
     - field.field.node.article.field_child_gender
     - field.field.node.article.field_content_category
     - field.field.node.article.field_cover_image
     - field.field.node.article.field_do_not_feature
+    - field.field.node.article.field_embedded_images
     - field.field.node.article.field_generic_content
     - field.field.node.article.field_keywords
     - field.field.node.article.field_licensed_content
+    - field.field.node.article.field_like_count
     - field.field.node.article.field_mandatory_content
     - field.field.node.article.field_meta_keywords
     - field.field.node.article.field_parent_gender
     - field.field.node.article.field_pre_populated
     - field.field.node.article.field_premature_content
+    - field.field.node.article.field_read_count
     - field.field.node.article.field_references_and_comments
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_related_video_articles
@@ -53,6 +59,8 @@ content:
     weight: 100
     region: content
 hidden:
+  feeds_item: true
+  field_analytics_updated: true
   field_australian_article: true
   field_body_rendered: true
   field_child_age: true
@@ -64,11 +72,13 @@ hidden:
   field_generic_content: true
   field_keywords: true
   field_licensed_content: true
+  field_like_count: true
   field_mandatory_content: true
   field_meta_keywords: true
   field_parent_gender: true
   field_pre_populated: true
   field_premature_content: true
+  field_read_count: true
   field_references_and_comments: true
   field_related_articles: true
   field_related_video_articles: true

--- a/config/sync/core.entity_view_display.node.course.default.yml
+++ b/config/sync/core.entity_view_display.node.course.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.course.feeds_item
+    - field.field.node.course.field_analytics_updated
     - field.field.node.course.field_certificate
     - field.field.node.course.field_child_age
     - field.field.node.course.field_course_category
@@ -14,10 +16,12 @@ dependencies:
     - field.field.node.course.field_feedback_question
     - field.field.node.course.field_feedback_required
     - field.field.node.course.field_final_assessment
+    - field.field.node.course.field_like_count
     - field.field.node.course.field_module
     - field.field.node.course.field_module_numbering_style
     - field.field.node.course.field_modules_unlock
     - field.field.node.course.field_number_of_modules
+    - field.field.node.course.field_read_count
     - field.field.node.course.field_reference
     - field.field.node.course.field_target_audience
     - node.type.course
@@ -31,6 +35,30 @@ targetEntityType: node
 bundle: course
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_analytics_updated:
+    type: timestamp
+    label: above
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+      tooltip:
+        date_format: long
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings: {  }
+    weight: 119
+    region: content
   field_certificate:
     type: entity_reference_entity_view
     label: above
@@ -124,6 +152,15 @@ content:
     third_party_settings: {  }
     weight: 112
     region: content
+  field_like_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 117
+    region: content
   field_module:
     type: entity_reference_revisions_entity_view
     label: above
@@ -159,6 +196,15 @@ content:
     third_party_settings: {  }
     weight: 109
     region: content
+  field_read_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 118
+    region: content
   field_reference:
     type: string
     label: above
@@ -181,4 +227,5 @@ content:
     weight: 100
     region: content
 hidden:
+  feeds_item: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.course.full.yml
+++ b/config/sync/core.entity_view_display.node.course.full.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.course.feeds_item
+    - field.field.node.course.field_analytics_updated
     - field.field.node.course.field_certificate
     - field.field.node.course.field_child_age
     - field.field.node.course.field_course_category
@@ -15,10 +17,12 @@ dependencies:
     - field.field.node.course.field_feedback_question
     - field.field.node.course.field_feedback_required
     - field.field.node.course.field_final_assessment
+    - field.field.node.course.field_like_count
     - field.field.node.course.field_module
     - field.field.node.course.field_module_numbering_style
     - field.field.node.course.field_modules_unlock
     - field.field.node.course.field_number_of_modules
+    - field.field.node.course.field_read_count
     - field.field.node.course.field_reference
     - field.field.node.course.field_target_audience
     - node.type.course
@@ -186,4 +190,8 @@ content:
     weight: 1
     region: content
 hidden:
+  feeds_item: true
+  field_analytics_updated: true
+  field_like_count: true
+  field_read_count: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.course.teaser.yml
+++ b/config/sync/core.entity_view_display.node.course.teaser.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.course.feeds_item
+    - field.field.node.course.field_analytics_updated
     - field.field.node.course.field_certificate
     - field.field.node.course.field_child_age
     - field.field.node.course.field_course_category
@@ -15,10 +17,12 @@ dependencies:
     - field.field.node.course.field_feedback_question
     - field.field.node.course.field_feedback_required
     - field.field.node.course.field_final_assessment
+    - field.field.node.course.field_like_count
     - field.field.node.course.field_module
     - field.field.node.course.field_module_numbering_style
     - field.field.node.course.field_modules_unlock
     - field.field.node.course.field_number_of_modules
+    - field.field.node.course.field_read_count
     - field.field.node.course.field_reference
     - field.field.node.course.field_target_audience
     - node.type.course
@@ -29,12 +33,19 @@ targetEntityType: node
 bundle: course
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 100
     region: content
 hidden:
+  feeds_item: true
+  field_analytics_updated: true
   field_certificate: true
   field_child_age: true
   field_course_category: true
@@ -46,10 +57,12 @@ hidden:
   field_feedback_question: true
   field_feedback_required: true
   field_final_assessment: true
+  field_like_count: true
   field_module: true
   field_module_numbering_style: true
   field_modules_unlock: true
   field_number_of_modules: true
+  field_read_count: true
   field_reference: true
   field_target_audience: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.video_article.default.yml
+++ b/config/sync/core.entity_view_display.node.video_article.default.yml
@@ -4,19 +4,25 @@ status: true
 dependencies:
   config:
     - field.field.node.video_article.body
+    - field.field.node.video_article.feeds_item
+    - field.field.node.video_article.field_analytics_updated
     - field.field.node.video_article.field_australian_article
+    - field.field.node.video_article.field_body_rendered
     - field.field.node.video_article.field_child_age
     - field.field.node.video_article.field_child_gender
     - field.field.node.video_article.field_content_category
     - field.field.node.video_article.field_cover_video
+    - field.field.node.video_article.field_embedded_images
     - field.field.node.video_article.field_generic_content
     - field.field.node.video_article.field_keywords
     - field.field.node.video_article.field_licensed_content
+    - field.field.node.video_article.field_like_count
     - field.field.node.video_article.field_mandatory_content
     - field.field.node.video_article.field_meta_keywords
     - field.field.node.video_article.field_parent_gender
     - field.field.node.video_article.field_pre_populated
     - field.field.node.video_article.field_premature_content
+    - field.field.node.video_article.field_read_count
     - field.field.node.video_article.field_references_and_comments
     - field.field.node.video_article.field_related_articles
     - field.field.node.video_article.field_related_video_articles
@@ -43,6 +49,25 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_analytics_updated:
+    type: timestamp
+    label: above
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+      tooltip:
+        date_format: long
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings: {  }
+    weight: 119
     region: content
   field_australian_article:
     type: boolean
@@ -115,6 +140,15 @@ content:
     third_party_settings: {  }
     weight: 104
     region: content
+  field_like_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 117
+    region: content
   field_mandatory_content:
     type: boolean
     label: above
@@ -149,6 +183,15 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 106
+    region: content
+  field_read_count:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 118
     region: content
   field_references_and_comments:
     type: text_default

--- a/config/sync/core.entity_view_display.node.video_article.full.yml
+++ b/config/sync/core.entity_view_display.node.video_article.full.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.video_article.body
+    - field.field.node.video_article.feeds_item
+    - field.field.node.video_article.field_analytics_updated
     - field.field.node.video_article.field_australian_article
     - field.field.node.video_article.field_body_rendered
     - field.field.node.video_article.field_child_age
@@ -15,11 +17,13 @@ dependencies:
     - field.field.node.video_article.field_generic_content
     - field.field.node.video_article.field_keywords
     - field.field.node.video_article.field_licensed_content
+    - field.field.node.video_article.field_like_count
     - field.field.node.video_article.field_mandatory_content
     - field.field.node.video_article.field_meta_keywords
     - field.field.node.video_article.field_parent_gender
     - field.field.node.video_article.field_pre_populated
     - field.field.node.video_article.field_premature_content
+    - field.field.node.video_article.field_read_count
     - field.field.node.video_article.field_references_and_comments
     - field.field.node.video_article.field_related_articles
     - field.field.node.video_article.field_related_video_articles
@@ -197,8 +201,11 @@ content:
     region: content
 hidden:
   feeds_item: true
+  field_analytics_updated: true
   field_body_rendered: true
   field_embedded_images: true
+  field_like_count: true
   field_meta_keywords: true
   field_pre_populated: true
+  field_read_count: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.video_article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.video_article.teaser.yml
@@ -5,19 +5,25 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.video_article.body
+    - field.field.node.video_article.feeds_item
+    - field.field.node.video_article.field_analytics_updated
     - field.field.node.video_article.field_australian_article
+    - field.field.node.video_article.field_body_rendered
     - field.field.node.video_article.field_child_age
     - field.field.node.video_article.field_child_gender
     - field.field.node.video_article.field_content_category
     - field.field.node.video_article.field_cover_video
+    - field.field.node.video_article.field_embedded_images
     - field.field.node.video_article.field_generic_content
     - field.field.node.video_article.field_keywords
     - field.field.node.video_article.field_licensed_content
+    - field.field.node.video_article.field_like_count
     - field.field.node.video_article.field_mandatory_content
     - field.field.node.video_article.field_meta_keywords
     - field.field.node.video_article.field_parent_gender
     - field.field.node.video_article.field_pre_populated
     - field.field.node.video_article.field_premature_content
+    - field.field.node.video_article.field_read_count
     - field.field.node.video_article.field_references_and_comments
     - field.field.node.video_article.field_related_articles
     - field.field.node.video_article.field_related_video_articles
@@ -52,6 +58,7 @@ content:
     region: content
 hidden:
   feeds_item: true
+  field_analytics_updated: true
   field_australian_article: true
   field_body_rendered: true
   field_child_age: true
@@ -62,11 +69,13 @@ hidden:
   field_generic_content: true
   field_keywords: true
   field_licensed_content: true
+  field_like_count: true
   field_mandatory_content: true
   field_meta_keywords: true
   field_parent_gender: true
   field_pre_populated: true
   field_premature_content: true
+  field_read_count: true
   field_references_and_comments: true
   field_related_articles: true
   field_related_video_articles: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -10,6 +10,7 @@ module:
   automated_cron: 0
   basic_auth: 0
   bebbo_serializer: 0
+  better_exposed_filters: 0
   big_pipe: 0
   block: 0
   block_content: 0
@@ -89,6 +90,7 @@ module:
   options: 0
   path: 0
   path_alias: 0
+  pb_content_analytics: 0
   pb_custom_field: 0
   pb_custom_form: 0
   pb_custom_migrate: 0

--- a/config/sync/feeds.feed_type.analytics_import_activities.yml
+++ b/config/sync/feeds.feed_type.analytics_import_activities.yml
@@ -1,0 +1,73 @@
+uuid: 10b3f35d-8ff7-425c-953f-e2c529ff2c45
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.activities.field_like_count
+    - field.field.node.activities.field_read_count
+    - node.type.activities
+  module:
+    - node
+label: 'Content Analytics Import - Activities'
+id: analytics_import_activities
+description: 'Import like and read counts for activities nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'public://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 100
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: activities
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  skip_validation: false
+  skip_validation_types: {  }
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/config/sync/feeds.feed_type.analytics_import_course.yml
+++ b/config/sync/feeds.feed_type.analytics_import_course.yml
@@ -1,0 +1,73 @@
+uuid: 997badca-25a7-49b3-ad10-43736f1a8924
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.course.field_like_count
+    - field.field.node.course.field_read_count
+    - node.type.course
+  module:
+    - node
+label: 'Content Analytics Import - Course'
+id: analytics_import_course
+description: 'Import like and read counts for course nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'public://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 100
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: course
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  skip_validation: false
+  skip_validation_types: {  }
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/config/sync/feeds.feed_type.analytics_import_video_article.yml
+++ b/config/sync/feeds.feed_type.analytics_import_video_article.yml
@@ -1,0 +1,73 @@
+uuid: 12d46497-ac9f-4db4-b727-2f7e72b0c76d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.video_article.field_like_count
+    - field.field.node.video_article.field_read_count
+    - node.type.video_article
+  module:
+    - node
+label: 'Content Analytics Import - Video Article'
+id: analytics_import_video_article
+description: 'Import like and read counts for video article nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'public://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 100
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: video_article
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  skip_validation: false
+  skip_validation_types: {  }
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/config/sync/feeds.feed_type.content_analytics_import.yml
+++ b/config/sync/feeds.feed_type.content_analytics_import.yml
@@ -1,0 +1,73 @@
+uuid: b6287be0-6596-44b5-9c1e-2900ece8a05a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.field_like_count
+    - field.field.node.article.field_read_count
+    - node.type.article
+  module:
+    - node
+label: 'Content Analytics Import'
+id: content_analytics_import
+description: 'Import like and read counts for content nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'public://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 100
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: article
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  skip_validation: false
+  skip_validation_types: {  }
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/config/sync/feeds.feed_type.content_health_check_up_language.yml
+++ b/config/sync/feeds.feed_type.content_health_check_up_language.yml
@@ -15,7 +15,7 @@ import_period: -1
 fetcher: upload
 fetcher_configuration:
   allowed_extensions: 'txt csv tsv xml opml'
-  directory: 'private://feeds'
+  directory: 'public://feeds'
 parser: csv
 parser_configuration:
   delimiter: ','
@@ -30,6 +30,8 @@ processor_configuration:
   update_existing: 1
   update_non_existent: _keep
   skip_hash_check: false
+  skip_validation: false
+  skip_validation_types: {  }
   authorize: true
   revision: false
   expire: -1

--- a/config/sync/field.field.node.activities.feeds_item.yml
+++ b/config/sync/field.field.node.activities.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 81ab4524-e379-4978-8260-9027ca8b012b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.feeds_item
+    - node.type.activities
+  module:
+    - feeds
+id: node.activities.feeds_item
+field_name: feeds_item
+entity_type: node
+bundle: activities
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.node.activities.field_analytics_updated.yml
+++ b/config/sync/field.field.node.activities.field_analytics_updated.yml
@@ -1,0 +1,24 @@
+uuid: c6697a62-7516-4516-8174-0b52501b0eec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - node.type.activities
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.activities.field_analytics_updated
+field_name: field_analytics_updated
+entity_type: node
+bundle: activities
+label: 'Analytics Updated'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.node.activities.field_like_count.yml
+++ b/config/sync/field.field.node.activities.field_like_count.yml
@@ -1,0 +1,28 @@
+uuid: 1eb2300f-7bf0-409d-a931-1cc4cacfc713
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - node.type.activities
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.activities.field_like_count
+field_name: field_like_count
+entity_type: node
+bundle: activities
+label: 'Like Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.activities.field_read_count.yml
+++ b/config/sync/field.field.node.activities.field_read_count.yml
@@ -1,0 +1,28 @@
+uuid: dfab55ea-9414-4988-b89d-944ed1ed3a94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_read_count
+    - node.type.activities
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.activities.field_read_count
+field_name: field_read_count
+entity_type: node
+bundle: activities
+label: 'Read Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.article.feeds_item.yml
+++ b/config/sync/field.field.node.article.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 67764794-e9a2-4332-a48b-1d2b5c85b9d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.feeds_item
+    - node.type.article
+  module:
+    - feeds
+id: node.article.feeds_item
+field_name: feeds_item
+entity_type: node
+bundle: article
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.node.article.field_analytics_updated.yml
+++ b/config/sync/field.field.node.article.field_analytics_updated.yml
@@ -1,0 +1,24 @@
+uuid: 5bb76c42-9e19-4046-875d-0e942c9eb859
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - node.type.article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.article.field_analytics_updated
+field_name: field_analytics_updated
+entity_type: node
+bundle: article
+label: 'Analytics Updated'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.node.article.field_like_count.yml
+++ b/config/sync/field.field.node.article.field_like_count.yml
@@ -1,0 +1,28 @@
+uuid: 9d4d5fbb-45e2-4a1f-85d6-631cfddd83f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - node.type.article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.article.field_like_count
+field_name: field_like_count
+entity_type: node
+bundle: article
+label: 'Like Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.article.field_read_count.yml
+++ b/config/sync/field.field.node.article.field_read_count.yml
@@ -1,0 +1,28 @@
+uuid: cd142b62-e0fc-49aa-bf33-1e42624a34bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_read_count
+    - node.type.article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.article.field_read_count
+field_name: field_read_count
+entity_type: node
+bundle: article
+label: 'Read Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.course.feeds_item.yml
+++ b/config/sync/field.field.node.course.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: f17a35bb-52ba-47b7-a78a-0bb7a575e3c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.feeds_item
+    - node.type.course
+  module:
+    - feeds
+id: node.course.feeds_item
+field_name: feeds_item
+entity_type: node
+bundle: course
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.node.course.field_analytics_updated.yml
+++ b/config/sync/field.field.node.course.field_analytics_updated.yml
@@ -1,0 +1,24 @@
+uuid: f57c3318-877c-46c1-819c-877e585f91ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - node.type.course
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.course.field_analytics_updated
+field_name: field_analytics_updated
+entity_type: node
+bundle: course
+label: 'Analytics Updated'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.node.course.field_like_count.yml
+++ b/config/sync/field.field.node.course.field_like_count.yml
@@ -1,0 +1,28 @@
+uuid: 7d166888-89ae-478a-b3ed-eb3dcd06578c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - node.type.course
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.course.field_like_count
+field_name: field_like_count
+entity_type: node
+bundle: course
+label: 'Like Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.course.field_read_count.yml
+++ b/config/sync/field.field.node.course.field_read_count.yml
@@ -1,0 +1,28 @@
+uuid: 19aa917c-bc63-410f-a92b-0a9c8129901a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_read_count
+    - node.type.course
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.course.field_read_count
+field_name: field_read_count
+entity_type: node
+bundle: course
+label: 'Read Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.video_article.feeds_item.yml
+++ b/config/sync/field.field.node.video_article.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 2b303616-70df-4377-b8ea-3868a59be05e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.feeds_item
+    - node.type.video_article
+  module:
+    - feeds
+id: node.video_article.feeds_item
+field_name: feeds_item
+entity_type: node
+bundle: video_article
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.node.video_article.field_analytics_updated.yml
+++ b/config/sync/field.field.node.video_article.field_analytics_updated.yml
@@ -1,0 +1,24 @@
+uuid: f5e2d4e4-b12c-4e62-9ded-1410a6bad0d3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - node.type.video_article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.video_article.field_analytics_updated
+field_name: field_analytics_updated
+entity_type: node
+bundle: video_article
+label: 'Analytics Updated'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.node.video_article.field_like_count.yml
+++ b/config/sync/field.field.node.video_article.field_like_count.yml
@@ -1,0 +1,28 @@
+uuid: 4575672e-3d79-4d6f-8fed-9c6cb6bbfd82
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - node.type.video_article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.video_article.field_like_count
+field_name: field_like_count
+entity_type: node
+bundle: video_article
+label: 'Like Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.video_article.field_read_count.yml
+++ b/config/sync/field.field.node.video_article.field_read_count.yml
@@ -1,0 +1,28 @@
+uuid: 52a8c069-8e2b-42e1-bb8b-536e4aa18f74
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_read_count
+    - node.type.video_article
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.video_article.field_read_count
+field_name: field_read_count
+entity_type: node
+bundle: video_article
+label: 'Read Count'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.storage.node.field_analytics_updated.yml
+++ b/config/sync/field.storage.node.field_analytics_updated.yml
@@ -1,0 +1,18 @@
+uuid: a78d8166-e36f-4d2e-973c-bfcadb7604e3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_analytics_updated
+field_name: field_analytics_updated
+entity_type: node
+type: timestamp
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_like_count.yml
+++ b/config/sync/field.storage.node.field_like_count.yml
@@ -1,0 +1,20 @@
+uuid: 50bd971c-0199-4687-9436-a28e4011442b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_like_count
+field_name: field_like_count
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_read_count.yml
+++ b/config/sync/field.storage.node.field_read_count.yml
@@ -1,0 +1,20 @@
+uuid: f9c9129b-b229-4a2d-9a18-0e1898ba58e2
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_read_count
+field_name: field_read_count
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/view_custom_table.tables.yml
+++ b/config/sync/view_custom_table.tables.yml
@@ -4,3 +4,9 @@ forcefull_check_update_api:
   description: ''
   column_relations: 'a:1:{s:2:"id";s:4:"node";}'
   created_by: '1'
+pb_analytics_sync_log:
+  table_name: pb_analytics_sync_log
+  table_database: default
+  description: 'Content analytics sync run log'
+  column_relations: 'a:0:{}'
+  created_by: '1'

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -211,7 +211,7 @@ display:
           type: user_name
         langcode:
           id: langcode
-          table: node
+          table: node_field_data
           field: langcode
           relationship: none
           group_type: group
@@ -219,7 +219,7 @@ display:
           entity_type: node
           entity_field: langcode
           plugin_id: field_language
-          label: language
+          label: Language
           exclude: false
           alter:
             alter_text: false
@@ -252,7 +252,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -575,7 +575,8 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value: {  }
+          value:
+            en: en
           group: 1
           exposed: true
           expose:
@@ -593,6 +594,11 @@ display:
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
+              global_admin: '0'
+              reviewer: '0'
+              editor: '0'
+              sme: '0'
+              se: '0'
               administrator: '0'
             reduce: false
           is_grouped: false
@@ -729,7 +735,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      rendering_language: '***LANGUAGE_language_interface***'
+      rendering_language: '***LANGUAGE_entity_translation***'
       display_extenders: {  }
       path: admin/content/node
       menu:
@@ -748,6 +754,7 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args

--- a/config/sync/views.view.content_analytics.yml
+++ b/config/sync/views.view.content_analytics.yml
@@ -1,0 +1,1381 @@
+uuid: 1cf4cceb-113f-44ac-a33e-140416d15db8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+    - node.type.activities
+    - node.type.article
+    - node.type.course
+    - node.type.video_article
+  module:
+    - better_exposed_filters
+    - csv_serialization
+    - datetime
+    - node
+    - rest
+    - serialization
+    - user
+    - views_data_export
+id: content_analytics
+label: 'Content Analytics'
+module: views
+description: 'Engagement analytics for article, video article, course, and activities content.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Content Analytics'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+          label: 'Original language'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_like_count:
+          id: field_like_count
+          table: node__field_like_count
+          field: field_like_count
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Like count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_read_count:
+          id: field_read_count
+          table: node__field_read_count
+          field: field_read_count
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Read count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_analytics_updated:
+          id: field_analytics_updated
+          table: node__field_analytics_updated
+          field: field_analytics_updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: medium
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ›
+            previous: ‹
+            first: «
+            last: »
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: full_html
+          bef:
+            general:
+              autosubmit: false
+              auto_submit_sort_only: false
+              autosubmit_breakpoint: ''
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_textfield_minimum_length: 3
+              autosubmit_hide: false
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              reset_button_always_show: false
+            filter:
+              nid:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  open_by_default: false
+                  is_secondary: false
+                  hide_label: false
+                  field_classes: ''
+                  sort_options_unsupported: ''
+              type_exposed:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  sort_options_method: alphabetical_asc
+                  sort_options_natural: true
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  open_by_default: false
+                  is_secondary: false
+                  hide_label: false
+                  field_classes: ''
+              langcode:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  sort_options_method: alphabetical_asc
+                  sort_options_natural: true
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  open_by_default: false
+                  is_secondary: false
+                  hide_label: false
+                  field_classes: ''
+      access:
+        type: perm
+        options:
+          perm: 'view content analytics report'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: nid
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            article: article
+            video_article: video_article
+            course: course
+            activities: activities
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        type_exposed:
+          id: type_exposed
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_exposed_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_exposed_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Content type'
+            description: null
+            identifier: type_exposed
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+              4: {  }
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          entity_type: node
+          entity_field: nid
+          plugin_id: numeric
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: nid_op
+            label: 'Search by ID'
+            description: ''
+            use_operator: false
+            operator: nid_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: nid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: 'Original language'
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          row_class: ''
+          default_row_class: true
+          columns:
+            nid: nid
+            title: title
+            type: type
+            langcode: langcode
+            field_like_count: field_like_count
+            field_read_count: field_read_count
+            field_analytics_updated: field_analytics_updated
+          default: nid
+          info:
+            nid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_like_count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_read_count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_analytics_updated:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'
+  data_export_1:
+    id: data_export_1
+    display_title: 'CSV Export'
+    display_plugin: data_export
+    position: 2
+    display_options:
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            article: article
+            video_article: video_article
+            course: course
+            activities: activities
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        type_exposed:
+          id: type_exposed
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_exposed_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_exposed_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Content type'
+            description: ''
+            identifier: type_exposed
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Article
+                operator: in
+                value:
+                  article: article
+                  all: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              2:
+                title: Course
+                operator: in
+                value:
+                  course: course
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              3:
+                title: Games
+                operator: in
+                value:
+                  activities: activities
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              4:
+                title: 'Video Article'
+                operator: in
+                value:
+                  video_article: video_article
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          entity_type: node
+          entity_field: nid
+          plugin_id: numeric
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: nid_op
+            label: 'Search by ID'
+            description: ''
+            use_operator: false
+            operator: nid_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: nid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: 'Original language'
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '1'
+            use_serializer_encode_only: false
+      defaults:
+        style: false
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: admin/config/content-analytics/report/csv
+      displays:
+        default: default
+        page_1: page_1
+      filename: content-analytics.csv
+      automatic_download: true
+      store_in_public_file_directory: false
+      custom_redirect_path: false
+      redirect_to_display: page_1
+      include_query_params: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          entity_type: node
+          entity_field: nid
+          plugin_id: numeric
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: nid_op
+            label: 'Search by ID'
+            description: ''
+            use_operator: false
+            operator: nid_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: nid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            article: article
+            video_article: video_article
+            course: course
+            activities: activities
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        type_exposed:
+          id: type_exposed
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            article: article
+            course: course
+            activities: activities
+            video_article: video_article
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_exposed_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_exposed_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              global_admin: '0'
+              reviewer: '0'
+              editor: '0'
+              sme: '0'
+              se: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Content type'
+            description: ''
+            identifier: type_exposed
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Article
+                operator: in
+                value:
+                  article: article
+                  all: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              2:
+                title: Course
+                operator: in
+                value:
+                  course: course
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              3:
+                title: Games
+                operator: in
+                value:
+                  activities: activities
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+                  video_article: '0'
+              4:
+                title: 'Video Article'
+                operator: in
+                value:
+                  video_article: video_article
+                  all: '0'
+                  article: '0'
+                  page: '0'
+                  child_development: '0'
+                  child_growth: '0'
+                  course: '0'
+                  daily_homescreen_messages: '0'
+                  faq: '0'
+                  activities: '0'
+                  guide: '0'
+                  health_check_ups: '0'
+                  survey: '0'
+                  milestone: '0'
+                  pregnancy_weekly_overview: '0'
+                  quiz: '0'
+                  vaccinations: '0'
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            en: en
+          group: 1
+          exposed: false
+          expose:
+            operator_id: langcode_op
+            label: 'Translation language'
+            description: null
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: admin/config/content-analytics/report
+      menu:
+        type: none
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'

--- a/config/sync/views.view.content_analytics_sync_log.yml
+++ b/config/sync/views.view.content_analytics_sync_log.yml
@@ -1,0 +1,740 @@
+uuid: e3cd73da-576a-4e3c-8c8f-b368d8c837ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - view_custom_table
+id: content_analytics_sync_log
+label: 'Content Analytics Sync Log'
+module: views
+description: 'Sync run history for the Content Analytics module.'
+tag: ''
+base_table: pb_analytics_sync_log
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Content Analytics Sync Log'
+      fields:
+        id:
+          id: id
+          table: pb_analytics_sync_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        sync_time:
+          id: sync_time
+          table: pb_analytics_sync_log
+          field: sync_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Sync Time'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        status:
+          id: status
+          table: pb_analytics_sync_log
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        triggered_by:
+          id: triggered_by
+          table: pb_analytics_sync_log
+          field: triggered_by
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Triggered By'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        nodes_processed:
+          id: nodes_processed
+          table: pb_analytics_sync_log
+          field: nodes_processed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Processed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        nodes_updated:
+          id: nodes_updated
+          table: pb_analytics_sync_log
+          field: nodes_updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        nodes_skipped:
+          id: nodes_skipped
+          table: pb_analytics_sync_log
+          field: nodes_skipped
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Skipped
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        error_message:
+          id: error_message
+          table: pb_analytics_sync_log
+          field: error_message
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Error Message'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '-'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 30
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10, 30'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manage content analytics sync'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        id:
+          id: id
+          table: pb_analytics_sync_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: id
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: pb_analytics_sync_log
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: Status
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Success
+                operator: '='
+                value: success
+              2:
+                title: Failure
+                operator: '='
+                value: failure
+        triggered_by:
+          id: triggered_by
+          table: pb_analytics_sync_log
+          field: triggered_by
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: triggered_by_op
+            label: 'Triggered By'
+            description: ''
+            use_operator: false
+            operator: triggered_by_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: triggered_by
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: 'Triggered By'
+            description: ''
+            identifier: triggered_by
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Cron
+                operator: '='
+                value: cron
+              2:
+                title: Manual
+                operator: '='
+                value: manual
+              3:
+                title: Feed
+                operator: '='
+                value: feeds
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            sync_time: sync_time
+            status: status
+            triggered_by: triggered_by
+            nodes_processed: nodes_processed
+            nodes_updated: nodes_updated
+            nodes_skipped: nodes_skipped
+            error_message: error_message
+          default: id
+          info:
+            id:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sync_time:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            triggered_by:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_processed:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_updated:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_skipped:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            error_message:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/content-analytics/logs
+      menu:
+        type: none
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_activities.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_activities.yml
@@ -1,0 +1,69 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+  module:
+    - node
+label: 'Content Analytics Import - Activities'
+id: analytics_import_activities
+description: 'Import like and read counts for activities nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'private://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 0
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: activities
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_course.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_course.yml
@@ -1,0 +1,69 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+  module:
+    - node
+label: 'Content Analytics Import - Course'
+id: analytics_import_course
+description: 'Import like and read counts for course nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'private://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 0
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: course
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_video_article.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.analytics_import_video_article.yml
@@ -1,0 +1,69 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+  module:
+    - node
+label: 'Content Analytics Import - Video Article'
+id: analytics_import_video_article
+description: 'Import like and read counts for video article nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: csv
+  directory: 'private://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 0
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: video_article
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.content_analytics_import.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/feeds.feed_type.content_analytics_import.yml
@@ -1,0 +1,69 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+  module:
+    - node
+label: 'Content Analytics Import'
+id: content_analytics_import
+description: 'Import like and read counts for content nodes via CSV upload.'
+help: 'Upload a CSV with columns: node_id, like_count, read_count'
+import_period: -1
+fetcher: upload
+fetcher_configuration:
+  allowed_extensions: 'csv'
+  directory: 'private://feeds'
+parser: csv
+parser_configuration:
+  delimiter: ','
+  no_headers: false
+  line_limit: 0
+processor: 'entity:node'
+processor_configuration:
+  values:
+    type: article
+  langcode: en
+  insert_new: 0
+  update_existing: 1
+  update_non_existent: _keep
+  skip_hash_check: false
+  authorize: false
+  revision: false
+  expire: -1
+  owner_feed_author: false
+  owner_id: 1
+custom_sources:
+  node_id:
+    value: node_id
+    label: node_id
+    machine_name: node_id
+  like_count:
+    value: like_count
+    label: like_count
+    machine_name: like_count
+  read_count:
+    value: read_count
+    label: read_count
+    machine_name: read_count
+mappings:
+  -
+    target: nid
+    map:
+      value: node_id
+    settings: {  }
+    unique:
+      value: '1'
+  -
+    target: field_like_count
+    map:
+      value: like_count
+    settings: {  }
+    unique: {  }
+  -
+    target: field_read_count
+    map:
+      value: read_count
+    settings: {  }
+    unique: {  }

--- a/docroot/modules/custom/pb_content_analytics/config/install/views.view.content_analytics.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/views.view.content_analytics.yml
@@ -1,0 +1,813 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_analytics_updated
+    - field.storage.node.field_like_count
+    - field.storage.node.field_read_count
+    - node.type.activities
+    - node.type.article
+    - node.type.course
+    - node.type.video_article
+  module:
+    - datetime
+    - node
+    - user
+    - views_data_export
+id: content_analytics
+label: 'Content Analytics'
+module: views
+description: 'Engagement analytics for article, video article, course, and activities content.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Content Analytics'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+          label: 'Original language'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_like_count:
+          id: field_like_count
+          table: node__field_like_count
+          field: field_like_count
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Like count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_read_count:
+          id: field_read_count
+          table: node__field_read_count
+          field: field_read_count
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Read count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_analytics_updated:
+          id: field_analytics_updated
+          table: node__field_analytics_updated
+          field: field_analytics_updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            format_type: medium
+            timezone_override: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: '›'
+            previous: '‹'
+            first: '«'
+            last: '»'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view content analytics report'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: nid
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            article: article
+            video_article: video_article
+            course: course
+            activities: activities
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        type_exposed:
+          id: type_exposed
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_exposed_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_exposed_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          entity_type: node
+          entity_field: nid
+          plugin_id: numeric
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: nid_op
+            label: 'Search by ID'
+            description: ''
+            use_operator: false
+            operator: nid_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: nid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: 'Original language'
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          row_class: ''
+          default_row_class: true
+          columns:
+            nid: nid
+            title: title
+            type: type
+            langcode: langcode
+            field_like_count: field_like_count
+            field_read_count: field_read_count
+            field_analytics_updated: field_analytics_updated
+          default: nid
+          info:
+            nid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_like_count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_read_count:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_analytics_updated:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/content-analytics/report
+      menu:
+        type: none
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'
+  data_export_1:
+    id: data_export_1
+    display_title: 'CSV Export'
+    display_plugin: data_export
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: admin/config/content-analytics/report/csv
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '1'
+            use_serializer_encode_only: false
+      defaults:
+        style: false
+      filename: 'content-analytics.csv'
+      automatic_download: true
+      store_in_public_file_directory: false
+      custom_redirect_path: false
+      redirect_to_display: page_1
+      include_query_params: true
+      displays:
+        page_1: '0'
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_analytics_updated'
+        - 'config:field.storage.node.field_like_count'
+        - 'config:field.storage.node.field_read_count'

--- a/docroot/modules/custom/pb_content_analytics/config/install/views.view.content_analytics_sync_log.yml
+++ b/docroot/modules/custom/pb_content_analytics/config/install/views.view.content_analytics_sync_log.yml
@@ -1,0 +1,735 @@
+uuid: e3cd73da-576a-4e3c-8c8f-b368d8c837ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - view_custom_table
+id: content_analytics_sync_log
+label: 'Content Analytics Sync Log'
+module: views
+description: 'Sync run history for the Content Analytics module.'
+tag: ''
+base_table: pb_analytics_sync_log
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Content Analytics Sync Log'
+      fields:
+        id:
+          id: id
+          table: pb_analytics_sync_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        sync_time:
+          id: sync_time
+          table: pb_analytics_sync_log
+          field: sync_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Sync Time'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        status:
+          id: status
+          table: pb_analytics_sync_log
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        triggered_by:
+          id: triggered_by
+          table: pb_analytics_sync_log
+          field: triggered_by
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Triggered By'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        nodes_processed:
+          id: nodes_processed
+          table: pb_analytics_sync_log
+          field: nodes_processed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Processed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        nodes_updated:
+          id: nodes_updated
+          table: pb_analytics_sync_log
+          field: nodes_updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        nodes_skipped:
+          id: nodes_skipped
+          table: pb_analytics_sync_log
+          field: nodes_skipped
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Skipped
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        error_message:
+          id: error_message
+          table: pb_analytics_sync_log
+          field: error_message
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Error Message'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '-'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 30
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10, 30'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manage content analytics sync'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        id:
+          id: id
+          table: pb_analytics_sync_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: id
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: pb_analytics_sync_log
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: Status
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Success
+                operator: '='
+                value: success
+              2:
+                title: Failure
+                operator: '='
+                value: failure
+        triggered_by:
+          id: triggered_by
+          table: pb_analytics_sync_log
+          field: triggered_by
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: triggered_by_op
+            label: 'Triggered By'
+            description: ''
+            use_operator: false
+            operator: triggered_by_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: triggered_by
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: 'Triggered By'
+            description: ''
+            identifier: triggered_by
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Cron
+                operator: '='
+                value: cron
+              2:
+                title: Manual
+                operator: '='
+                value: manual
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            sync_time: sync_time
+            status: status
+            triggered_by: triggered_by
+            nodes_processed: nodes_processed
+            nodes_updated: nodes_updated
+            nodes_skipped: nodes_skipped
+            error_message: error_message
+          default: id
+          info:
+            id:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sync_time:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            triggered_by:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_processed:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_updated:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nodes_skipped:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            error_message:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/content-analytics/logs
+      menu:
+        type: none
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/pb_content_analytics/js/csv-export-relocate.js
+++ b/docroot/modules/custom/pb_content_analytics/js/csv-export-relocate.js
@@ -1,0 +1,35 @@
+(function (Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.contentAnalyticsCsvRelocate = {
+    attach: function () {
+      var form = document.querySelector('.views-exposed-form');
+      if (!form) {
+        return;
+      }
+
+      var processed = once('csv-relocate', form);
+      if (!processed.length) {
+        return;
+      }
+
+      var feedLink = document.querySelector('.feed-icons .csv-feed a');
+      if (!feedLink) {
+        return;
+      }
+
+      feedLink.className = 'button button--secondary';
+      feedLink.textContent = 'Export data in CSV';
+
+      var wrapper = document.createElement('div');
+      wrapper.style.marginLeft = 'auto';
+      wrapper.appendChild(feedLink);
+      form.appendChild(wrapper);
+
+      var feedIcons = document.querySelector('.feed-icons');
+      if (feedIcons && !feedIcons.querySelector('a')) {
+        feedIcons.remove();
+      }
+    }
+  };
+})(Drupal, once);

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.info.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.info.yml
@@ -1,0 +1,6 @@
+name: Content Analytics
+description: Content analytics tracking and sync for Bebbo app
+type: module
+package: custom
+module: pb_content_analytics
+core_version_requirement: ^9.2 || ^10 || ^11

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.install
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.install
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for the Content Analytics module.
+ */
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Implements hook_schema().
+ */
+function pb_content_analytics_schema() {
+  $schema['pb_analytics_sync_log'] = [
+    'description' => 'Stores content analytics sync log entries.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique log entry ID.',
+      ],
+      'sync_time' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'description' => 'ISO datetime when sync was executed.',
+      ],
+      'status' => [
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+        'description' => 'Sync result: success or failure.',
+      ],
+      'nodes_processed' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Total nodes received from BigQuery API.',
+      ],
+      'nodes_updated' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Nodes actually written to the database.',
+      ],
+      'nodes_skipped' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Nodes skipped (up to date or not found).',
+      ],
+      'error_message' => [
+        'type' => 'text',
+        'not null' => FALSE,
+        'description' => 'Full error string on failure.',
+      ],
+      'triggered_by' => [
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+        'description' => 'cron or manual.',
+      ],
+    ],
+    'primary key' => ['id'],
+  ];
+  return $schema;
+}
+
+/**
+ * Implements hook_install().
+ */
+function pb_content_analytics_install() {
+  $content_types = ['article', 'video_article', 'course', 'activities'];
+
+  $fields = [
+    'field_like_count' => [
+      'type' => 'integer',
+      'label' => 'Like count',
+    ],
+    'field_read_count' => [
+      'type' => 'integer',
+      'label' => 'Read count',
+    ],
+    'field_analytics_updated' => [
+      'type' => 'datetime',
+      'label' => 'Analytics updated',
+    ],
+  ];
+
+  foreach ($fields as $field_name => $definition) {
+    if (!FieldStorageConfig::loadByName('node', $field_name)) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'type' => $definition['type'],
+        'translatable' => FALSE,
+      ])->save();
+    }
+
+    foreach ($content_types as $bundle) {
+      if (!FieldConfig::loadByName('node', $bundle, $field_name)) {
+        FieldConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'node',
+          'bundle' => $bundle,
+          'label' => $definition['label'],
+          'required' => FALSE,
+        ])->save();
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function pb_content_analytics_uninstall() {
+  $content_types = ['article', 'video_article', 'course', 'activities'];
+  $field_names = ['field_like_count', 'field_read_count', 'field_analytics_updated'];
+
+  foreach ($field_names as $field_name) {
+    foreach ($content_types as $bundle) {
+      $field = FieldConfig::loadByName('node', $bundle, $field_name);
+      if ($field) {
+        $field->delete();
+      }
+    }
+    $storage = FieldStorageConfig::loadByName('node', $field_name);
+    if ($storage) {
+      $storage->delete();
+    }
+  }
+
+  \Drupal::database()->schema()->dropTable('pb_analytics_sync_log');
+}

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.libraries.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.libraries.yml
@@ -1,0 +1,6 @@
+csv-export-relocate:
+  js:
+    js/csv-export-relocate.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.links.menu.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.links.menu.yml
@@ -1,0 +1,27 @@
+pb_content_analytics.settings:
+  title: 'Content Analytics Settings'
+  route_name: pb_content_analytics.settings
+  parent: system.admin_config
+  description: 'Configure Content Analytics API settings and sync schedule'
+  weight: 150
+
+pb_content_analytics.reports:
+  title: 'Content Analytics Report'
+  route_name: view.content_analytics.page_1
+  parent: pb_content_analytics.settings
+  description: 'View content engagement analytics'
+  weight: 0
+
+pb_content_analytics.sync:
+  title: 'Content Analytics Sync'
+  route_name: pb_content_analytics.sync
+  parent: pb_content_analytics.settings
+  description: 'Manage content analytics sync'
+  weight: 1
+
+pb_content_analytics.logs:
+  title: 'Content Analytics Logs'
+  route_name: view.content_analytics_sync_log.page_1
+  parent: pb_content_analytics.settings
+  description: 'View content analytics sync run history'
+  weight: 2

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.links.task.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.links.task.yml
@@ -1,0 +1,22 @@
+pb_content_analytics.settings_tab:
+  title: 'Settings'
+  route_name: pb_content_analytics.settings
+  base_route: pb_content_analytics.settings
+
+pb_content_analytics.reports_tab:
+  title: 'Report'
+  route_name: view.content_analytics.page_1
+  base_route: pb_content_analytics.settings
+  weight: 1
+
+pb_content_analytics.sync_tab:
+  title: 'Sync'
+  route_name: pb_content_analytics.sync
+  base_route: pb_content_analytics.settings
+  weight: 2
+
+pb_content_analytics.logs_tab:
+  title: 'Logs'
+  route_name: view.content_analytics_sync_log.page_1
+  base_route: pb_content_analytics.settings
+  weight: 3

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.module
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.module
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * @file
+ * Content Analytics module for Bebbo app.
+ */
+
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_cron().
+ */
+function pb_content_analytics_cron(): void {
+  /** @var \Drupal\pb_content_analytics\Service\AnalyticsSyncService $sync_service */
+  $sync_service = \Drupal::service('pb_content_analytics.sync_service');
+  $logger = \Drupal::logger('pb_content_analytics');
+
+  if (!$sync_service->isSyncEnabled()) {
+    $logger->info('Cron: analytics sync is disabled, skipping.');
+    return;
+  }
+
+  if (!$sync_service->isAutoSyncEnabled()) {
+    $logger->info('Cron: auto-sync is disabled, skipping.');
+    return;
+  }
+
+  $frequency = $sync_service->getSyncFrequency();
+  $interval = $frequency === 'daily' ? 86400 : 604800;
+
+  $last = $sync_service->getLastSuccessfulSyncLog();
+  if ($last) {
+    $last_time = strtotime($last['sync_time']);
+    $elapsed = time() - $last_time;
+    if ($elapsed < $interval) {
+      $remaining = $interval - $elapsed;
+      $logger->info('Cron: last sync was @elapsed s ago (@freq interval = @interval s). Next sync in @remaining s.', [
+        '@elapsed' => $elapsed,
+        '@freq' => $frequency,
+        '@interval' => $interval,
+        '@remaining' => $remaining,
+      ]);
+      return;
+    }
+  }
+
+  $logger->info('Cron: starting BigQuery analytics sync (@freq).', ['@freq' => $frequency]);
+
+  try {
+    $data = $sync_service->fetchFromBigQuery();
+    $logger->info('Cron: fetched @count records from BigQuery.', ['@count' => count($data)]);
+    $stats = $sync_service->processBatch($data);
+    $sync_service->logSyncResult($stats, 'cron');
+    $logger->info('Cron: sync complete — @processed processed, @updated updated, @skipped skipped.', [
+      '@processed' => $stats['processed'],
+      '@updated' => $stats['updated'],
+      '@skipped' => $stats['skipped'],
+    ]);
+  }
+  catch (\RuntimeException $e) {
+    $sync_service->logSyncResult(
+      ['processed' => 0, 'updated' => 0, 'skipped' => 0],
+      'cron',
+      $e->getMessage()
+    );
+    $logger->error('Cron sync failed: @message', ['@message' => $e->getMessage()]);
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * - Adds a CSV download button to the Content Analytics
+ *   report exposed filter form.
+ * - Disables analytics fields on node add/edit forms so they are visible
+ *   but cannot be edited by the user.
+ */
+function pb_content_analytics_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+  if ($form_id === 'views_exposed_form') {
+    $storage = $form_state->getStorage();
+    if (!empty($storage['view']) && $storage['view']->id() === 'content_analytics') {
+      $form['#attached']['library'][] = 'pb_content_analytics/csv-export-relocate';
+    }
+    return;
+  }
+
+  $form_object = $form_state->getFormObject();
+  if (!$form_object instanceof EntityFormInterface) {
+    return;
+  }
+
+  $entity = $form_object->getEntity();
+  if (!$entity instanceof FieldableEntityInterface || $entity->getEntityTypeId() !== 'node') {
+    return;
+  }
+
+  $analytics_fields = ['field_like_count', 'field_read_count', 'field_analytics_updated'];
+
+  foreach ($analytics_fields as $field_name) {
+    if (isset($form[$field_name])) {
+      $form[$field_name]['#disabled'] = TRUE;
+    }
+  }
+}
+
+/**
+ * Implements hook_node_view().
+ */
+function pb_content_analytics_node_view(array &$build, EntityInterface $entity, $display, $view_mode): void {
+  $supported_types = ['article', 'video_article', 'course', 'activities'];
+  if (!in_array($entity->bundle(), $supported_types, TRUE)) {
+    return;
+  }
+
+  if (!$entity instanceof FieldableEntityInterface) {
+    return;
+  }
+
+  /** @var \Drupal\pb_content_analytics\Service\AnalyticsSyncService $sync_service */
+  $sync_service = \Drupal::service('pb_content_analytics.sync_service');
+  if (!$sync_service->isSyncEnabled()) {
+    return;
+  }
+
+  $build['field_like_count'] = [
+    '#type'   => 'item',
+    '#title'  => t('Like count'),
+    '#markup' => (string) ($entity->get('field_like_count')->value ?? 0),
+    '#weight' => 100,
+  ];
+
+  $build['field_read_count'] = [
+    '#type'   => 'item',
+    '#title'  => t('Read count'),
+    '#markup' => (string) ($entity->get('field_read_count')->value ?? 0),
+    '#weight' => 101,
+  ];
+}

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.permissions.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.permissions.yml
@@ -1,0 +1,11 @@
+administer content analytics settings:
+  title: 'Administer content analytics settings'
+  description: 'Configure Content Analytics API settings'
+
+manage content analytics sync:
+  title: 'Manage content analytics sync'
+  description: 'Trigger manual sync and view sync status'
+
+view content analytics report:
+  title: 'View content analytics report'
+  description: 'Access the Content Analytics report'

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.routing.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.routing.yml
@@ -1,0 +1,29 @@
+pb_content_analytics.settings:
+  path: '/admin/config/content-analytics/settings'
+  defaults:
+    _form: '\Drupal\pb_content_analytics\Form\ContentAnalyticsSettingsForm'
+    _title: 'Content Analytics Settings'
+  requirements:
+    _permission: 'administer content analytics settings'
+  options:
+    _admin_route: TRUE
+
+pb_content_analytics.sync:
+  path: '/admin/config/content-analytics/sync'
+  defaults:
+    _form: '\Drupal\pb_content_analytics\Form\ContentAnalyticsSyncForm'
+    _title: 'Content Analytics Sync'
+  requirements:
+    _permission: 'manage content analytics sync'
+  options:
+    _admin_route: TRUE
+
+pb_content_analytics.sync_now:
+  path: '/admin/config/content-analytics/sync/now'
+  defaults:
+    _controller: '\Drupal\pb_content_analytics\Controller\AnalyticsSyncController::syncNow'
+    _title: 'Sync Now'
+  requirements:
+    _permission: 'manage content analytics sync'
+  options:
+    _admin_route: TRUE

--- a/docroot/modules/custom/pb_content_analytics/pb_content_analytics.services.yml
+++ b/docroot/modules/custom/pb_content_analytics/pb_content_analytics.services.yml
@@ -1,0 +1,12 @@
+services:
+  logger.channel.pb_content_analytics:
+    parent: logger.channel_base
+    arguments: ['pb_content_analytics']
+  pb_content_analytics.sync_service:
+    class: Drupal\pb_content_analytics\Service\AnalyticsSyncService
+    arguments: ['@http_client', '@database', '@entity_type.manager', '@config.factory', '@logger.channel.pb_content_analytics']
+  pb_content_analytics.feeds_import_subscriber:
+    class: Drupal\pb_content_analytics\EventSubscriber\FeedsImportSubscriber
+    arguments: ['@pb_content_analytics.sync_service']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/pb_content_analytics/src/Controller/AnalyticsSyncController.php
+++ b/docroot/modules/custom/pb_content_analytics/src/Controller/AnalyticsSyncController.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\pb_content_analytics\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\pb_content_analytics\Service\AnalyticsSyncService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Controller for triggering a manual content analytics sync via Batch API.
+ */
+class AnalyticsSyncController extends ControllerBase {
+
+  /**
+   * The analytics sync service.
+   *
+   * @var \Drupal\pb_content_analytics\Service\AnalyticsSyncService
+   */
+  protected AnalyticsSyncService $syncService;
+
+  /**
+   * Constructs an AnalyticsSyncController.
+   *
+   * @param \Drupal\pb_content_analytics\Service\AnalyticsSyncService $sync_service
+   *   The analytics sync service.
+   */
+  public function __construct(AnalyticsSyncService $sync_service) {
+    $this->syncService = $sync_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('pb_content_analytics.sync_service')
+    );
+  }
+
+  /**
+   * Fetches analytics data and runs a Batch API sync.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect to sync form after batch is set up.
+   */
+  public function syncNow(): RedirectResponse {
+    if (!$this->syncService->isSyncEnabled()) {
+      $this->messenger()->addWarning($this->t('Content Analytics is disabled. Enable it in settings before syncing.'));
+      return $this->redirect('pb_content_analytics.sync');
+    }
+
+    try {
+      $data = $this->syncService->fetchFromBigQuery();
+    }
+    catch (\RuntimeException $e) {
+      $this->syncService->logSyncResult(
+        ['processed' => 0, 'updated' => 0, 'skipped' => 0],
+        'manual',
+        $e->getMessage()
+      );
+      $this->messenger()->addError($this->t('Sync failed: @message', ['@message' => $e->getMessage()]));
+      return $this->redirect('pb_content_analytics.sync');
+    }
+
+    $chunks = array_chunk($data, 100, TRUE);
+    $total = count($data);
+
+    $operations = [];
+    foreach ($chunks as $chunk) {
+      $operations[] = [
+        [static::class, 'batchProcessChunk'],
+        [$chunk, $total],
+      ];
+    }
+
+    $batch = [
+      'title' => $this->t('Syncing content analytics…'),
+      'operations' => $operations,
+      'finished' => [static::class, 'batchFinished'],
+      'init_message' => $this->t('Starting sync of @total nodes…', ['@total' => $total]),
+      'progress_message' => $this->t('Processing batch @current of @total…'),
+      'error_message' => $this->t('An error occurred during the sync.'),
+    ];
+
+    batch_set($batch);
+
+    return batch_process($this->redirect('pb_content_analytics.sync')->getTargetUrl());
+  }
+
+  /**
+   * Batch operation: process one chunk of node analytics.
+   *
+   * @param array<string, array<string, mixed>> $chunk
+   *   A slice of the BigQuery response.
+   * @param int $total
+   *   Total number of nodes in the full sync run.
+   * @param array<string, mixed> $context
+   *   Batch API context array passed by reference.
+   */
+  public static function batchProcessChunk(array $chunk, int $total, array &$context): void {
+    if (empty($context['results'])) {
+      $context['results'] = ['processed' => 0, 'updated' => 0, 'skipped' => 0];
+    }
+
+    $sync_service = \Drupal::service('pb_content_analytics.sync_service');
+    $stats = $sync_service->processBatch($chunk);
+
+    $context['results']['processed'] += $stats['processed'];
+    $context['results']['updated'] += $stats['updated'];
+    $context['results']['skipped'] += $stats['skipped'];
+
+    $context['message'] = t('Processing nodes… @processed / @total — updated: @updated, skipped: @skipped', [
+      '@processed' => $context['results']['processed'],
+      '@total' => $total,
+      '@updated' => $context['results']['updated'],
+      '@skipped' => $context['results']['skipped'],
+    ]);
+  }
+
+  /**
+   * Batch finished callback: logs result and displays status message.
+   *
+   * @param bool $success
+   *   Whether the batch completed without PHP errors.
+   * @param array<string, int> $results
+   *   Aggregated processed/updated/skipped counts.
+   * @param array<int, mixed> $operations
+   *   Any unprocessed operations (non-empty on failure).
+   */
+  public static function batchFinished(bool $success, array $results, array $operations): void {
+    $sync_service = \Drupal::service('pb_content_analytics.sync_service');
+
+    if ($success) {
+      $sync_service->logSyncResult($results, 'manual');
+      \Drupal::messenger()->addStatus(t('Sync complete. Processed: @p, Updated: @u, Skipped: @s.', [
+        '@p' => $results['processed'] ?? 0,
+        '@u' => $results['updated'] ?? 0,
+        '@s' => $results['skipped'] ?? 0,
+      ]));
+    }
+    else {
+      $error = t('Batch sync did not complete successfully.');
+      $sync_service->logSyncResult(
+        $results + ['processed' => 0, 'updated' => 0, 'skipped' => 0],
+        'manual',
+        (string) $error
+      );
+      \Drupal::messenger()->addError($error);
+    }
+  }
+
+}

--- a/docroot/modules/custom/pb_content_analytics/src/EventSubscriber/FeedsImportSubscriber.php
+++ b/docroot/modules/custom/pb_content_analytics/src/EventSubscriber/FeedsImportSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\pb_content_analytics\EventSubscriber;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\feeds\Event\EntityEvent;
+use Drupal\feeds\Event\FeedsEvents;
+use Drupal\feeds\Event\ImportFinishedEvent;
+use Drupal\pb_content_analytics\Service\AnalyticsSyncService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Sets analytics timestamp on feed items and logs completed imports.
+ */
+class FeedsImportSubscriber implements EventSubscriberInterface {
+
+  protected const ANALYTICS_FEED_TYPES = [
+    'content_analytics_import',
+    'analytics_import_video_article',
+    'analytics_import_course',
+    'analytics_import_activities',
+  ];
+
+  public function __construct(
+    protected readonly AnalyticsSyncService $syncService,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      FeedsEvents::PROCESS_ENTITY_PRESAVE => 'onEntityPresave',
+      FeedsEvents::IMPORT_FINISHED => 'onImportFinished',
+    ];
+  }
+
+  /**
+   * Sets the analytics updated timestamp before each entity is saved.
+   */
+  public function onEntityPresave(EntityEvent $event): void {
+    $feed = $event->getFeed();
+    if (!in_array($feed->getType()->id(), self::ANALYTICS_FEED_TYPES, TRUE)) {
+      return;
+    }
+
+    $entity = $event->getEntity();
+    if (!$entity instanceof FieldableEntityInterface || $entity->getEntityTypeId() !== 'node') {
+      return;
+    }
+
+    $entity->set('field_analytics_updated', time());
+  }
+
+  /**
+   * Logs a sync result when an analytics feed import completes.
+   */
+  public function onImportFinished(ImportFinishedEvent $event): void {
+    $feed = $event->getFeed();
+    if (!in_array($feed->getType()->id(), self::ANALYTICS_FEED_TYPES, TRUE)) {
+      return;
+    }
+
+    $item_count = (int) $feed->get('item_count')->value;
+    $this->syncService->logSyncResult([
+      'processed' => $item_count,
+      'updated' => $item_count,
+      'skipped' => 0,
+    ], 'feeds');
+  }
+
+}

--- a/docroot/modules/custom/pb_content_analytics/src/Form/ContentAnalyticsSettingsForm.php
+++ b/docroot/modules/custom/pb_content_analytics/src/Form/ContentAnalyticsSettingsForm.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\pb_content_analytics\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configuration form for Content Analytics settings.
+ */
+class ContentAnalyticsSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['pb_content_analytics.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'pb_content_analytics_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('pb_content_analytics.settings');
+
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Content Analytics'),
+      '#description' => $this->t('When enabled, analytics data will be synced from the BigQuery endpoint.'),
+      '#default_value' => $config->get('enabled'),
+    ];
+
+    $form['api_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('BigQuery API URL'),
+      '#description' => $this->t('Full endpoint URL for the BigQuery analytics API.'),
+      '#default_value' => $config->get('api_url'),
+      '#maxlength' => 512,
+      '#states' => [
+        'visible' => [':input[name="enabled"]' => ['checked' => TRUE]],
+      ],
+    ];
+
+    $form['api_key'] = [
+      '#type' => 'password',
+      '#title' => $this->t('X-API-Key'),
+      '#description' => $this->t('API key sent as the X-API-Key request header. Leave blank to keep the existing value.'),
+      '#default_value' => '',
+      '#states' => [
+        'visible' => [':input[name="enabled"]' => ['checked' => TRUE]],
+      ],
+    ];
+
+    $form['auto_sync_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable auto-sync'),
+      '#description' => $this->t('Allow cron to trigger analytics sync automatically.'),
+      '#default_value' => $config->get('auto_sync_enabled'),
+      '#states' => [
+        'visible' => [':input[name="enabled"]' => ['checked' => TRUE]],
+      ],
+    ];
+
+    $form['sync_frequency'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Sync frequency'),
+      '#options' => [
+        'daily' => $this->t('Daily'),
+        'weekly' => $this->t('Weekly'),
+      ],
+      '#default_value' => $config->get('sync_frequency') ?: 'weekly',
+      '#states' => [
+        'visible' => [
+          ':input[name="enabled"]' => ['checked' => TRUE],
+          ':input[name="auto_sync_enabled"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $config = $this->config('pb_content_analytics.settings');
+    $config
+      ->set('enabled', (bool) $form_state->getValue('enabled'))
+      ->set('api_url', $form_state->getValue('api_url'))
+      ->set('auto_sync_enabled', (bool) $form_state->getValue('auto_sync_enabled'))
+      ->set('sync_frequency', $form_state->getValue('sync_frequency'));
+
+    // Only overwrite the API key if a new value was provided.
+    $api_key = $form_state->getValue('api_key');
+    if (!empty($api_key)) {
+      $config->set('api_key', $api_key);
+    }
+
+    $config->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/docroot/modules/custom/pb_content_analytics/src/Form/ContentAnalyticsSyncForm.php
+++ b/docroot/modules/custom/pb_content_analytics/src/Form/ContentAnalyticsSyncForm.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\pb_content_analytics\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\pb_content_analytics\Service\AnalyticsSyncService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for displaying sync status and triggering a manual sync.
+ */
+class ContentAnalyticsSyncForm extends FormBase {
+
+  /**
+   * The analytics sync service.
+   *
+   * @var \Drupal\pb_content_analytics\Service\AnalyticsSyncService
+   */
+  protected AnalyticsSyncService $syncService;
+
+  /**
+   * Constructs a ContentAnalyticsSyncForm.
+   *
+   * @param \Drupal\pb_content_analytics\Service\AnalyticsSyncService $sync_service
+   *   The analytics sync service.
+   */
+  public function __construct(AnalyticsSyncService $sync_service) {
+    $this->syncService = $sync_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('pb_content_analytics.sync_service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'pb_content_analytics_sync_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $enabled = $this->syncService->isSyncEnabled();
+
+    $form['status'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Feature status'),
+      '#markup' => $enabled
+        ? '<span style="color:green">' . $this->t('Enabled') . '</span>'
+        : '<span style="color:red">' . $this->t('Disabled') . '</span>',
+    ];
+
+    $last = $this->syncService->getLastSyncLog();
+
+    if ($last) {
+      $form['last_sync_time'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Last sync'),
+        '#markup' => $this->t('@time (triggered by: @by)', [
+          '@time' => $last['sync_time'],
+          '@by' => $last['triggered_by'],
+        ]),
+      ];
+
+      $form['last_sync_status'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Last sync status'),
+        '#markup' => $last['status'] === 'success'
+          ? '<span style="color:green">' . $this->t('Success') . '</span>'
+          : '<span style="color:red">' . $this->t('Failure') . '</span>',
+      ];
+
+      if ($last['status'] === 'failure' && !empty($last['error_message'])) {
+        $form['last_sync_error'] = [
+          '#type' => 'item',
+          '#title' => $this->t('Error'),
+          '#markup' => '<code>' . $this->t('@error', ['@error' => $last['error_message']]) . '</code>',
+        ];
+      }
+
+      $form['last_sync_counts'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Nodes processed / updated / skipped'),
+        '#markup' => $this->t('@processed / @updated / @skipped', [
+          '@processed' => $last['nodes_processed'],
+          '@updated' => $last['nodes_updated'],
+          '@skipped' => $last['nodes_skipped'],
+        ]),
+      ];
+    }
+    else {
+      $form['no_sync'] = [
+        '#type' => 'item',
+        '#markup' => $this->t('No sync has been run yet.'),
+      ];
+    }
+
+    if ($enabled) {
+      $form['actions'] = ['#type' => 'actions'];
+      $form['actions']['sync_now'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Sync Now'),
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $form_state->setRedirectUrl(
+      Url::fromRoute('pb_content_analytics.sync_now')
+    );
+  }
+
+}

--- a/docroot/modules/custom/pb_content_analytics/src/Service/AnalyticsSyncService.php
+++ b/docroot/modules/custom/pb_content_analytics/src/Service/AnalyticsSyncService.php
@@ -1,0 +1,380 @@
+<?php
+
+namespace Drupal\pb_content_analytics\Service;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for syncing content analytics data from BigQuery.
+ */
+class AnalyticsSyncService {
+
+  /**
+   * Maps BigQuery content_type values to Drupal bundle names.
+   */
+  private const CONTENT_TYPE_MAP = [
+    'article' => 'article',
+    'video_article' => 'video_article',
+    'course' => 'course',
+    'game' => 'activities',
+  ];
+
+  /**
+   * The HTTP client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $database;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructs an AnalyticsSyncService.
+   */
+  public function __construct(
+    ClientInterface $http_client,
+    Connection $database,
+    EntityTypeManagerInterface $entity_type_manager,
+    ConfigFactoryInterface $config_factory,
+    LoggerInterface $logger,
+  ) {
+    $this->httpClient = $http_client;
+    $this->database = $database;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Returns TRUE if the analytics feature is enabled in settings.
+   */
+  public function isSyncEnabled(): bool {
+    return (bool) $this->configFactory
+      ->get('pb_content_analytics.settings')
+      ->get('enabled');
+  }
+
+  /**
+   * Returns TRUE if auto-sync (cron) is enabled in settings.
+   */
+  public function isAutoSyncEnabled(): bool {
+    return (bool) $this->configFactory
+      ->get('pb_content_analytics.settings')
+      ->get('auto_sync_enabled');
+  }
+
+  /**
+   * Returns the configured sync frequency: 'daily' or 'weekly'.
+   */
+  public function getSyncFrequency(): string {
+    return $this->configFactory
+      ->get('pb_content_analytics.settings')
+      ->get('sync_frequency') ?: 'weekly';
+  }
+
+  /**
+   * Fetches analytics data from the BigQuery HTTP endpoint.
+   *
+   * @return array<string, array<string, mixed>>
+   *   Decoded JSON response keyed by node ID string.
+   *
+   * @throws \RuntimeException
+   *   On HTTP or JSON decode failure.
+   */
+  public function fetchFromBigQuery(): array {
+    $config = $this->configFactory->get('pb_content_analytics.settings');
+    $url = $config->get('api_url');
+    $api_key = $config->get('api_key');
+
+    try {
+      $response = $this->httpClient->request('GET', $url, [
+        'headers' => ['X-API-Key' => $api_key],
+        'timeout' => 30,
+      ]);
+
+      $body = (string) $response->getBody();
+      $data = json_decode($body, TRUE);
+
+      if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new \RuntimeException('JSON decode error: ' . json_last_error_msg());
+      }
+
+      return is_array($data) ? $data : [];
+    }
+    catch (GuzzleException $e) {
+      throw new \RuntimeException('BigQuery HTTP request failed: ' . $e->getMessage(), 0, $e);
+    }
+  }
+
+  /**
+   * Processes a batch of analytics data, updating node field tables directly.
+   *
+   * @param array<string, array<string, mixed>> $data
+   *   Node analytics keyed by node ID string.
+   * @param callable|null $progressCallback
+   *   Optional callback receiving [$processed, $total, $updated, $skipped].
+   *
+   * @return array{processed: int, updated: int, skipped: int}
+   *   Sync counts.
+   */
+  public function processBatch(array $data, ?callable $progressCallback = NULL): array {
+    $total = count($data);
+    $processed = 0;
+    $updated = 0;
+    $skipped = 0;
+
+    foreach ($data as $nid_string => $item) {
+      $nid = (int) $nid_string;
+
+      // Map content type; skip unknown types.
+      $api_type = $item['content_type'] ?? '';
+      if (!isset(self::CONTENT_TYPE_MAP[$api_type])) {
+        $skipped++;
+        $processed++;
+        if ($progressCallback) {
+          ($progressCallback)([$processed, $total, $updated, $skipped]);
+        }
+        continue;
+      }
+      $bundle = self::CONTENT_TYPE_MAP[$api_type];
+
+      // Verify nid exists with the expected bundle.
+      $exists = $this->database->select('node', 'n')
+        ->fields('n', ['nid'])
+        ->condition('n.nid', $nid)
+        ->condition('n.type', $bundle)
+        ->execute()
+        ->fetchField();
+
+      if (!$exists) {
+        $skipped++;
+        $processed++;
+        if ($progressCallback) {
+          ($progressCallback)([$processed, $total, $updated, $skipped]);
+        }
+        continue;
+      }
+
+      // Skip if BigQuery data is not newer than stored value.
+      $stored_updated = $this->database->select('node__field_analytics_updated', 'au')
+        ->fields('au', ['field_analytics_updated_value'])
+        ->condition('au.entity_id', $nid)
+        ->execute()
+        ->fetchField();
+
+      $bq_updated = $item['last_updated'] ?? '';
+      $bq_ts = $bq_updated ? (int) strtotime($bq_updated) : 0;
+      if ($stored_updated && $bq_ts <= (int) $stored_updated) {
+        $skipped++;
+        $processed++;
+        if ($progressCallback) {
+          ($progressCallback)([$processed, $total, $updated, $skipped]);
+        }
+        continue;
+      }
+
+      // Direct DB update on field tables.
+      $this->updateNodeFieldTables($nid, (int) ($item['total_likes'] ?? 0), (int) ($item['total_reads'] ?? 0), $bq_updated);
+
+      Cache::invalidateTags(['node:' . $nid]);
+
+      $updated++;
+      $processed++;
+      if ($progressCallback) {
+        ($progressCallback)([$processed, $total, $updated, $skipped]);
+      }
+    }
+
+    return [
+      'processed' => $processed,
+      'updated' => $updated,
+      'skipped' => $skipped,
+    ];
+  }
+
+  /**
+   * Writes like count, read count, and analytics updated timestamp directly.
+   */
+  private function updateNodeFieldTables(int $nid, int $likes, int $reads, string $updated_value): void {
+    // field_analytics_updated is a timestamp field — stores a Unix integer.
+    // BigQuery returns ISO 8601 strings; convert to int before direct DB write.
+    try {
+      $updated_ts = (new \DateTime($updated_value, new \DateTimeZone('UTC')))->getTimestamp();
+    }
+    catch (\Exception $e) {
+      $updated_ts = time();
+    }
+
+    $field_updates = [
+      'node__field_like_count' => ['field_like_count_value' => $likes],
+      'node__field_read_count' => ['field_read_count_value' => $reads],
+      'node__field_analytics_updated' => ['field_analytics_updated_value' => $updated_ts],
+    ];
+    $revision_updates = [
+      'node_revision__field_like_count' => ['field_like_count_value' => $likes],
+      'node_revision__field_read_count' => ['field_read_count_value' => $reads],
+      'node_revision__field_analytics_updated' => ['field_analytics_updated_value' => $updated_ts],
+    ];
+
+    foreach (array_merge($field_updates, $revision_updates) as $table => $fields) {
+      // Upsert: update if row exists, insert otherwise.
+      $exists = $this->database->select($table, 't')
+        ->fields('t', ['entity_id'])
+        ->condition('t.entity_id', $nid)
+        ->execute()
+        ->fetchField();
+
+      if ($exists) {
+        $this->database->update($table)
+          ->fields($fields)
+          ->condition('entity_id', $nid)
+          ->execute();
+      }
+      else {
+        // Non-translatable fields store one row per entity using the default
+        // language langcode. Always insert with default_langcode = 1.
+        $langcode = $this->database->select('node_field_data', 'n')
+          ->fields('n', ['langcode'])
+          ->condition('n.nid', $nid)
+          ->condition('n.default_langcode', 1)
+          ->execute()
+          ->fetchField() ?: 'en';
+
+        $vid = $this->database->select('node', 'n')
+          ->fields('n', ['vid'])
+          ->condition('n.nid', $nid)
+          ->execute()
+          ->fetchField();
+
+        $insert_fields = array_merge($fields, [
+          'bundle' => $this->getBundle($nid),
+          'deleted' => 0,
+          'entity_id' => $nid,
+          'revision_id' => $vid ?: $nid,
+          'langcode' => $langcode,
+          'delta' => 0,
+        ]);
+        $this->database->insert($table)
+          ->fields($insert_fields)
+          ->execute();
+      }
+    }
+  }
+
+  /**
+   * Retrieves the bundle (content type) for a given node ID.
+   */
+  private function getBundle(int $nid): string {
+    return $this->database->select('node', 'n')
+      ->fields('n', ['type'])
+      ->condition('n.nid', $nid)
+      ->execute()
+      ->fetchField() ?: '';
+  }
+
+  /**
+   * Logs a sync result row and prunes to the 30 most recent rows.
+   *
+   * @param array{processed: int, updated: int, skipped: int} $stats
+   *   Sync counts.
+   * @param string $triggered_by
+   *   Either 'cron' or 'manual'.
+   * @param string|null $error
+   *   Error message if sync failed.
+   */
+  public function logSyncResult(array $stats, string $triggered_by, ?string $error = NULL): void {
+    $this->database->insert('pb_analytics_sync_log')
+      ->fields([
+        'sync_time' => date('c'),
+        'status' => $error ? 'failure' : 'success',
+        'nodes_processed' => $stats['processed'] ?? 0,
+        'nodes_updated' => $stats['updated'] ?? 0,
+        'nodes_skipped' => $stats['skipped'] ?? 0,
+        'error_message' => $error,
+        'triggered_by' => $triggered_by,
+      ])
+      ->execute();
+
+    // Prune to the 30 most recent rows.
+    $ids = $this->database->select('pb_analytics_sync_log', 'l')
+      ->fields('l', ['id'])
+      ->orderBy('id', 'DESC')
+      ->execute()
+      ->fetchCol();
+
+    if (count($ids) > 30) {
+      $to_delete = array_slice($ids, 30);
+      $this->database->delete('pb_analytics_sync_log')
+        ->condition('id', $to_delete, 'IN')
+        ->execute();
+    }
+  }
+
+  /**
+   * Returns the most recent sync log row, or NULL if none exists.
+   *
+   * @return array<string, mixed>|null
+   *   Associative array of the log row, or NULL if no rows exist.
+   */
+  public function getLastSyncLog(): ?array {
+    $row = $this->database->select('pb_analytics_sync_log', 'l')
+      ->fields('l')
+      ->orderBy('id', 'DESC')
+      ->range(0, 1)
+      ->execute()
+      ->fetchAssoc();
+
+    return $row ?: NULL;
+  }
+
+  /**
+   * Returns the most recent successful sync log row, or NULL if none.
+   *
+   * @return array<string, mixed>|null
+   *   Associative array of the log row, or NULL if no successful sync exists.
+   */
+  public function getLastSuccessfulSyncLog(): ?array {
+    $row = $this->database->select('pb_analytics_sync_log', 'l')
+      ->fields('l')
+      ->condition('l.status', 'success')
+      ->orderBy('id', 'DESC')
+      ->range(0, 1)
+      ->execute()
+      ->fetchAssoc();
+
+    return $row ?: NULL;
+  }
+
+}


### PR DESCRIPTION
## Summary

- Adds a new custom Drupal module (`pb_content_analytics`) that syncs engagement metrics (like count, read count) from a BigQuery API into Drupal content nodes
- Supports 4 content types: **Article**, **Video Article**, **Course**, and **Activities**
- Provides both automated (cron-based) and manual (Batch API) sync, plus CSV feed import as a fallback
- Includes an admin dashboard with a tabbed interface: Settings, Report, Sync status, and Logs
- Adds a sortable, filterable Views-based analytics report with CSV export capability

## What Changed
### New Custom Module: `pb_content_analytics`

| File | Purpose |
|------|---------|
| `pb_content_analytics.info.yml` | Module definition (Drupal 9/10/11 compatible) |
| `pb_content_analytics.module` | Cron hook (auto-sync), form_alter (disable analytics fields on node forms, add CSV export button), node_view hook (display counts on node view) |
| `pb_content_analytics.install` | Schema for `pb_analytics_sync_log` table, hook_install creates 3 fields on 4 content types, hook_uninstall cleans up |
| `pb_content_analytics.routing.yml` | 3 admin routes: Settings form, Sync form, Sync Now controller |
| `pb_content_analytics.links.menu.yml` | Admin menu items under Configuration |
| `pb_content_analytics.links.task.yml` | Local task tabs: Settings, Report, Sync, Logs |
| `pb_content_analytics.permissions.yml` | 3 permissions: administer settings, manage sync, view report |
| `pb_content_analytics.services.yml` | Registers `AnalyticsSyncService` and `FeedsImportSubscriber` |
| `pb_content_analytics.libraries.yml` | JS library for CSV export button relocation |
| `src/Service/AnalyticsSyncService.php` | Core service: BigQuery fetch, batch processing, direct DB upsert, sync logging with auto-prune (keeps 30 rows) |
| `src/Form/ContentAnalyticsSettingsForm.php` | Config form: enable/disable, API URL, API key, auto-sync toggle, frequency (daily/weekly) |
| `src/Form/ContentAnalyticsSyncForm.php` | Sync status display + "Sync Now" button |
| `src/Controller/AnalyticsSyncController.php` | Manual sync controller using Batch API (chunked processing, 100 nodes/batch) |
| `src/EventSubscriber/FeedsImportSubscriber.php` | Sets `field_analytics_updated` timestamp on Feeds CSV import, logs import results |
| `js/csv-export-relocate.js` | Moves the CSV download link into the exposed filter form |

### New Fields (3 field storages, 12 field instances)

| Field | Type | Attached To |
|-------|------|-------------|
| `field_like_count` | Integer | article, video_article, course, activities |
| `field_read_count` | Integer | article, video_article, course, activities |
| `field_analytics_updated` | Datetime (timestamp) | article, video_article, course, activities |

### New Feed Types (4 CSV import configurations)

| Feed Type ID | Target Content Type |
|--------------|-------------------|
| `content_analytics_import` | Article |
| `analytics_import_video_article` | Video Article |
| `analytics_import_course` | Course |
| `analytics_import_activities` | Activities |

CSV format: `node_id, like_count, read_count` (maps to NID as unique key)

### New Views

| View | Purpose | Path |
|------|---------|------|
| `content_analytics` | Analytics report table with filters + CSV export | `/admin/config/content-analytics/report` |
| `content_analytics_sync_log` | Sync run history log | `/admin/config/content-analytics/logs` (via view_custom_table) |

### New Database Table

`pb_analytics_sync_log` — tracks sync runs with columns: id, sync_time, status, nodes_processed, nodes_updated, nodes_skipped, error_message, triggered_by

### Modules Enabled

- `pb_content_analytics` (new)
- `better_exposed_filters` (contrib, for enhanced Views filter UX)
- `dblog` (core, for watchdog logging visibility)

### Other Config Changes

- `config_ignore.settings.yml` — Added `pb_content_analytics.settings` to the ignore list (per-site API credentials)
- `view_custom_table.tables.yml` — Registered `pb_analytics_sync_log` custom table for Views integration
- `views.view.content.yml` — Minor fixes: corrected langcode table reference (`node` → `node_field_data`), capitalized "Language" label, set default language filter to English, updated rendering language to entity translation