### PR TITLE
Bebbo API Security Module — Device Attestation & JWT Authentication

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,6 +12,10 @@ database:
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
+# To enable bebbo_api_security JWT signing, replace the line above with:
+# web_environment:
+#   - BEBBO_JWT_PRIVATE_KEY=<base64-encoded-rsa-private-key>
+# Generate: openssl genrsa 2048 | base64 | tr -d '\n'
 corepack_enable: false
 
 # Key features of DDEV's config.yaml:

--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,8 @@
         "drupal/views_field_view": "^1.0@beta",
         "drupal/webp": "^1.0@RC",
         "enshrined/svg-sanitize": "^0.22.0",
+        "firebase/php-jwt": "^7.0@stable",
+        "spomky-labs/cbor-php": "^3.0",
         "webflo/drupal-finder": "^1.3.1"
     },
     "config": {
@@ -292,9 +294,13 @@
         "drush/drush": "^12.5.1",
         "mglaman/drupal-check": "^1.5",
         "mglaman/phpstan-drupal": "^1.1",
+        "mikey179/vfsstream": "^1.6",
         "overtrue/phplint": "^9.0",
+        "phpspec/prophecy-phpunit": "^2",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-deprecation-rules": "^1.1"
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "phpunit/phpunit": "^9",
+        "symfony/phpunit-bridge": "^6.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eda9ca27a8462fc2a4f85f73fce743ff",
+    "content-hash": "d844eb0f53b3c47a3a58175a34de6110",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -456,6 +456,65 @@
                 "source": "https://github.com/minkphp/MinkBrowserKitDriver/tree/v2.2.0"
             },
             "time": "2023-12-09T11:30:50+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.17.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.17.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-25T20:34:43+00:00"
         },
         {
             "name": "chi-teck/drupal-code-generator",
@@ -1810,29 +1869,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -1852,9 +1911,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -10415,6 +10474,70 @@
             "time": "2024-01-11T19:11:58+00:00"
         },
         {
+            "name": "firebase/php-jwt",
+            "version": "v7.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
+            },
+            "time": "2026-04-01T20:38:03+00:00"
+        },
+        {
             "name": "friends-of-behat/mink-extension",
             "version": "v2.7.5",
             "source": {
@@ -12517,16 +12640,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -12569,9 +12692,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "openai-php/client",
@@ -14126,6 +14249,77 @@
                 }
             ],
             "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
         },
         {
             "name": "steverhoades/oauth2-openid-connect-server",
@@ -17688,6 +17882,76 @@
             "time": "2025-07-17T20:45:56+00:00"
         },
         {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
             "name": "drupal/coder",
             "version": "8.3.30",
             "source": {
@@ -17934,6 +18198,118 @@
             "time": "2024-08-14T21:40:06+00:00"
         },
         {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5||^8.5||^9.6",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2024-08-29T18:43:31+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
             "name": "nette/neon",
             "version": "v3.4.4",
             "source": {
@@ -18095,6 +18471,426 @@
             "time": "2025-04-10T13:12:51+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.26.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "09c2e5949d676286358a62af818f8407167a9dd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/09c2e5949d676286358a62af818f8407167a9dd6",
+                "reference": "09c2e5949d676286358a62af818f8407167a9dd6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2 || ^2.0",
+                "php": "8.2.* || 8.3.* || 8.4.* || 8.5.*",
+                "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.1"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.93.1",
+                "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
+                "phpstan/phpstan": "^2.1.13, <2.1.34 || ^2.1.39",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "dev",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.26.1"
+            },
+            "time": "2026-04-13T14:35:16+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "89f91b01d0640b7820e427e02a007bc6489d8a26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/89f91b01d0640b7820e427e02a007bc6489d8a26",
+                "reference": "89f91b01d0640b7820e427e02a007bc6489d8a26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.18",
+                "phpunit/phpunit": "^9.1 || ^10.1 || ^11.0 || ^12.0 || ^13.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.5.0"
+            },
+            "time": "2026-02-09T15:40:55+00:00"
+        },
+        {
             "name": "phpstan/extension-installer",
             "version": "1.4.3",
             "source": {
@@ -18144,16 +18940,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -18185,9 +18981,1386 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -18642,6 +20815,211 @@
                 }
             ],
             "time": "2025-08-05T10:16:07+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v6.4.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "10b3646a631191501e73e83211fed9b19413e54e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/10b3646a631191501e73e83211fed9b19413e54e",
+                "reference": "10b3646a631191501e73e83211fed9b19413e54e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5|9.1.2"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-php81": "^1.27"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/sebastianbergmann/phpunit",
+                    "name": "phpunit/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "testing"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.4.35"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-04T13:04:47+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+            },
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],
@@ -18657,7 +21035,8 @@
         "drupal/tamper": 15,
         "drupal/ultimate_cron": 15,
         "drupal/views_field_view": 10,
-        "drupal/webp": 5
+        "drupal/webp": 5,
+        "firebase/php-jwt": 0
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/bebbo/language/sq/views.view.user_admin_people.yml
+++ b/config/bebbo/language/sq/views.view.user_admin_people.yml
@@ -24,6 +24,9 @@ display:
             group_items:
               1:
                 title: Active
+        permission:
+          expose:
+            label: Permission
   page_1:
     display_title: Faqe
     display_options:

--- a/config/sync/bebbo_api_security.settings.yml
+++ b/config/sync/bebbo_api_security.settings.yml
@@ -1,0 +1,16 @@
+_core:
+  default_config_hash: EcW22nkTrqZFTvCyKHGOjHd0n72N78muzkWvNhAyfAQ
+enforcement_mode: disabled
+dev_bypass_enabled: false
+dev_bypass_ips: ''
+google_package_name: ''
+google_project_number: ''
+google_verdict_freshness_seconds: 600
+apple_team_id: ''
+apple_bundle_id: ''
+apple_production_mode: true
+jwt_expiry_seconds: 3600
+refresh_expiry_seconds: 2592000
+refresh_rotation_enabled: true
+register_rate_limit: 10
+refresh_rate_limit: 30

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -3,6 +3,7 @@ _core:
 mode: simple
 ignored_config_entities:
   - admin_toolbar.settings
+  - bebbo_api_security.settings
   - 'entity_share_client.remote*'
   - google_analytics.settings
   - mobile_app_links.android_packages

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -14,6 +14,7 @@ module:
   autocomplete_id: 0
   automated_cron: 0
   basic_auth: 0
+  bebbo_api_security: 0
   bebbo_serializer: 0
   better_exposed_filters: 0
   big_pipe: 0
@@ -53,6 +54,7 @@ module:
   file_sanitizer: 0
   filelog: 0
   filter: 0
+  fpa: 0
   gin_toolbar: 0
   gnode: 0
   google_analytics: 0
@@ -64,6 +66,7 @@ module:
   imageapi_optimize_binaries: 0
   imagemagick: 0
   inline_entity_form: 0
+  js_cookie: 0
   jsonapi: 0
   jsonapi_extras: 0
   key: 0

--- a/config/sync/key.key.bebbo_google_sa_key.yml
+++ b/config/sync/key.key.bebbo_google_sa_key.yml
@@ -1,0 +1,18 @@
+uuid: 9e29725f-1475-4da1-92c3-8f8c1bcf7a88
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: TrzwDS2gi9Ij9X75Q1Vb2QHyqcdlOLqnkT0I1ziZrKE
+id: bebbo_google_sa_key
+label: 'Google Service Account Key (Play Integrity)'
+description: 'Google Cloud service account JSON key for Play Integrity API verification.'
+key_type: authentication
+key_type_settings: {  }
+key_provider: env
+key_provider_settings:
+  env_variable: BEBBO_GOOGLE_SA_KEY
+  base64_encoded: true
+  strip_line_breaks: false
+key_input: none
+key_input_settings: {  }

--- a/config/sync/key.key.bebbo_jwt_signing_key.yml
+++ b/config/sync/key.key.bebbo_jwt_signing_key.yml
@@ -1,0 +1,18 @@
+uuid: 3bbe5c50-154d-4083-8c0b-092c2fb1eb22
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: U-CqT16LQb6JNMQXqZ3kaj1ujq51djCzpTjYGiZRzBE
+id: bebbo_jwt_signing_key
+label: 'Bebbo JWT Signing Key (RSA)'
+description: 'RSA-2048 private key for signing JWT tokens. Stored as base64-encoded env var.'
+key_type: authentication
+key_type_settings: {  }
+key_provider: env
+key_provider_settings:
+  env_variable: BEBBO_JWT_PRIVATE_KEY
+  base64_encoded: true
+  strip_line_breaks: false
+key_input: none
+key_input_settings: {  }

--- a/config/sync/language/ro/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/ro/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,36 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        id:
+          format_plural_string: !!binary MQNAY291bnQ=
+        expires:
+          label: 'Expiră la'
+          format_plural_string: !!binary MQNAY291bnQ=
+        used:
+          format_plural_string: !!binary MQNAY291bnQ=
+        created:
+          label: Created
+          format_plural_string: !!binary MQNAY291bnQ=
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/ro/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/ro/views.view.bebbo_api_devices.yml
@@ -3,18 +3,16 @@ display:
     display_title: Default
     display_options:
       fields:
-        name:
-          label: Username
+        id:
+          format_plural_string: !!binary MQNAY291bnQ=
         status:
           label: Status
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Roles
-        operations:
-          label: Operations
-        mail:
-          separator: ', '
+        created:
+          label: Created
+          format_plural_string: !!binary MQNAY291bnQ=
+        updated:
+          label: Updated
+          format_plural_string: !!binary MQNAY291bnQ=
       pager:
         options:
           tags:
@@ -28,26 +26,15 @@ display:
             offset_label: Offset
       exposed_form:
         options:
-          submit_button: Filter
+          submit_button: Apply
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           sort_asc_label: Asc
           sort_desc_label: Desc
       filters:
         status:
-          group_info:
+          expose:
             label: Status
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Role
-        permission:
-          expose:
-            label: Permission
+      use_more_text: more
   page_1:
-    display_title: Страница
-    display_options:
-      menu:
-        title: List
+    display_title: Page

--- a/config/sync/language/ro/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/ro/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,36 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        id:
+          format_plural_string: !!binary MQNAY291bnQ=
+        expires:
+          label: 'Expiră la'
+          format_plural_string: !!binary MQNAY291bnQ=
+        revoked:
+          format_plural_string: !!binary MQNAY291bnQ=
+        created:
+          label: Created
+          format_plural_string: !!binary MQNAY291bnQ=
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/ro/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/ro/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,39 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        id:
+          format_plural_string: !!binary MQNAY291bnQ=
+        ip_address:
+          label: 'Adresă IP'
+        details:
+          label: Detalii
+        created:
+          label: Created
+          format_plural_string: !!binary MQNAY291bnQ=
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      filters:
+        ip_address:
+          expose:
+            label: 'Adresă IP'
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/ru/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/ru/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,27 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Применить
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+  page_1:
+    display_title: Страница

--- a/config/sync/language/ru/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/ru/views.view.bebbo_api_devices.yml
@@ -3,18 +3,12 @@ display:
     display_title: Default
     display_options:
       fields:
-        name:
-          label: Username
         status:
           label: Status
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Roles
-        operations:
-          label: Operations
-        mail:
-          separator: ', '
+        created:
+          label: Created
+        updated:
+          label: Updated
       pager:
         options:
           tags:
@@ -28,26 +22,14 @@ display:
             offset_label: Offset
       exposed_form:
         options:
-          submit_button: Filter
+          submit_button: Применить
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           sort_asc_label: Asc
           sort_desc_label: Desc
       filters:
         status:
-          group_info:
+          expose:
             label: Status
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Role
-        permission:
-          expose:
-            label: Permission
   page_1:
     display_title: Страница
-    display_options:
-      menu:
-        title: List

--- a/config/sync/language/ru/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/ru/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,27 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Применить
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+  page_1:
+    display_title: Страница

--- a/config/sync/language/ru/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/ru/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,27 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Применить
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+  page_1:
+    display_title: Страница

--- a/config/sync/language/sk/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/sk/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,30 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        expires:
+          label: Vyprší
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/sk/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/sk/views.view.bebbo_api_devices.yml
@@ -3,18 +3,12 @@ display:
     display_title: Default
     display_options:
       fields:
-        name:
-          label: Username
         status:
           label: Status
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Roles
-        operations:
-          label: Operations
-        mail:
-          separator: ', '
+        created:
+          label: Created
+        updated:
+          label: Updated
       pager:
         options:
           tags:
@@ -28,26 +22,15 @@ display:
             offset_label: Offset
       exposed_form:
         options:
-          submit_button: Filter
+          submit_button: Apply
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           sort_asc_label: Asc
           sort_desc_label: Desc
       filters:
         status:
-          group_info:
+          expose:
             label: Status
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Role
-        permission:
-          expose:
-            label: Permission
+      use_more_text: more
   page_1:
-    display_title: Страница
-    display_options:
-      menu:
-        title: List
+    display_title: Page

--- a/config/sync/language/sk/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/sk/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,30 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        expires:
+          label: Vyprší
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/sk/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/sk/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,36 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        ip_address:
+          label: 'IP adresa'
+        details:
+          label: Podrobnosti
+        created:
+          label: Created
+      pager:
+        options:
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page_label: 'Items per page'
+            items_per_page_options_all_label: '- All -'
+            offset_label: Offset
+      exposed_form:
+        options:
+          submit_button: Apply
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      filters:
+        ip_address:
+          expose:
+            label: 'IP adresa'
+      use_more_text: more
+  page_1:
+    display_title: Page

--- a/config/sync/language/sq/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/sq/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,12 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          reset_button_label: Reset
+  page_1:
+    display_title: Faqe

--- a/config/sync/language/sq/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/sq/views.view.bebbo_api_devices.yml
@@ -1,0 +1,18 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        status:
+          label: Status
+        created:
+          label: Created
+      exposed_form:
+        options:
+          reset_button_label: Reset
+      filters:
+        status:
+          expose:
+            label: Status
+  page_1:
+    display_title: Faqe

--- a/config/sync/language/sq/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/sq/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,12 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          reset_button_label: Reset
+  page_1:
+    display_title: Faqe

--- a/config/sync/language/sq/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/sq/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,12 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          reset_button_label: Reset
+  page_1:
+    display_title: Faqe

--- a/config/sync/language/sr/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/sr/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,10 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          exposed_sorts_label: 'Sort by'

--- a/config/sync/language/sr/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/sr/views.view.bebbo_api_devices.yml
@@ -1,0 +1,16 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        status:
+          label: Status
+        created:
+          label: Created
+      exposed_form:
+        options:
+          exposed_sorts_label: 'Sort by'
+      filters:
+        status:
+          expose:
+            label: Status

--- a/config/sync/language/sr/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/sr/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,10 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          exposed_sorts_label: 'Sort by'

--- a/config/sync/language/sr/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/sr/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,10 @@
+display:
+  default:
+    display_title: Default
+    display_options:
+      fields:
+        created:
+          label: Created
+      exposed_form:
+        options:
+          exposed_sorts_label: 'Sort by'

--- a/config/sync/language/uk/views.view.bebbo_api_challenges.yml
+++ b/config/sync/language/uk/views.view.bebbo_api_challenges.yml
@@ -3,16 +3,8 @@ display:
     display_title: Базово
     display_options:
       fields:
-        name:
-          label: "Ім'я користувача"
-        status:
-          label: Стан
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Ролі
-        operations:
-          label: Операції
+        created:
+          label: Created
       pager:
         options:
           tags:
@@ -26,26 +18,10 @@ display:
             offset_label: Зміщення
       exposed_form:
         options:
-          submit_button: Фільтр
+          submit_button: Застосувати
           reset_button_label: Скинути
           exposed_sorts_label: 'Впорядкувати за'
           sort_asc_label: Зрост
           sort_desc_label: Спад
-      filters:
-        status:
-          group_info:
-            label: Стан
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Роль
-        permission:
-          expose:
-            label: Permission
   page_1:
     display_title: Сторінка
-    display_options:
-      menu:
-        title: List

--- a/config/sync/language/uk/views.view.bebbo_api_devices.yml
+++ b/config/sync/language/uk/views.view.bebbo_api_devices.yml
@@ -3,16 +3,12 @@ display:
     display_title: Базово
     display_options:
       fields:
-        name:
-          label: "Ім'я користувача"
         status:
           label: Стан
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Ролі
-        operations:
-          label: Операції
+        created:
+          label: Created
+        updated:
+          label: Оновлено
       pager:
         options:
           tags:
@@ -26,26 +22,14 @@ display:
             offset_label: Зміщення
       exposed_form:
         options:
-          submit_button: Фільтр
+          submit_button: Застосувати
           reset_button_label: Скинути
           exposed_sorts_label: 'Впорядкувати за'
           sort_asc_label: Зрост
           sort_desc_label: Спад
       filters:
         status:
-          group_info:
+          expose:
             label: Стан
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Роль
-        permission:
-          expose:
-            label: Permission
   page_1:
     display_title: Сторінка
-    display_options:
-      menu:
-        title: List

--- a/config/sync/language/uk/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/language/uk/views.view.bebbo_api_refresh_tokens.yml
@@ -3,16 +3,8 @@ display:
     display_title: Базово
     display_options:
       fields:
-        name:
-          label: "Ім'я користувача"
-        status:
-          label: Стан
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Ролі
-        operations:
-          label: Операції
+        created:
+          label: Created
       pager:
         options:
           tags:
@@ -26,26 +18,10 @@ display:
             offset_label: Зміщення
       exposed_form:
         options:
-          submit_button: Фільтр
+          submit_button: Застосувати
           reset_button_label: Скинути
           exposed_sorts_label: 'Впорядкувати за'
           sort_asc_label: Зрост
           sort_desc_label: Спад
-      filters:
-        status:
-          group_info:
-            label: Стан
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Роль
-        permission:
-          expose:
-            label: Permission
   page_1:
     display_title: Сторінка
-    display_options:
-      menu:
-        title: List

--- a/config/sync/language/uk/views.view.bebbo_api_security_log.yml
+++ b/config/sync/language/uk/views.view.bebbo_api_security_log.yml
@@ -3,16 +3,8 @@ display:
     display_title: Базово
     display_options:
       fields:
-        name:
-          label: "Ім'я користувача"
-        status:
-          label: Стан
-          settings:
-            format_custom_true: Active
-        roles_target_id:
-          label: Ролі
-        operations:
-          label: Операції
+        created:
+          label: Created
       pager:
         options:
           tags:
@@ -26,26 +18,10 @@ display:
             offset_label: Зміщення
       exposed_form:
         options:
-          submit_button: Фільтр
+          submit_button: Застосувати
           reset_button_label: Скинути
           exposed_sorts_label: 'Впорядкувати за'
           sort_asc_label: Зрост
           sort_desc_label: Спад
-      filters:
-        status:
-          group_info:
-            label: Стан
-            group_items:
-              1:
-                title: Active
-        roles_target_id:
-          expose:
-            label: Роль
-        permission:
-          expose:
-            label: Permission
   page_1:
     display_title: Сторінка
-    display_options:
-      menu:
-        title: List

--- a/config/sync/view_custom_table.tables.yml
+++ b/config/sync/view_custom_table.tables.yml
@@ -10,3 +10,27 @@ pb_analytics_sync_log:
   description: 'Content analytics sync run log'
   column_relations: 'a:0:{}'
   created_by: '1'
+bebbo_api_devices:
+  table_name: bebbo_api_devices
+  table_database: default
+  description: 'Registered devices for API authentication'
+  column_relations: 'a:0:{}'
+  created_by: '1'
+bebbo_api_refresh_tokens:
+  table_name: bebbo_api_refresh_tokens
+  table_database: default
+  description: 'JWT refresh tokens with rotation tracking'
+  column_relations: 'a:0:{}'
+  created_by: '1'
+bebbo_api_challenges:
+  table_name: bebbo_api_challenges
+  table_database: default
+  description: 'Verification challenge nonces'
+  column_relations: 'a:0:{}'
+  created_by: '1'
+bebbo_api_security_log:
+  table_name: bebbo_api_security_log
+  table_database: default
+  description: 'Security event audit trail'
+  column_relations: 'a:0:{}'
+  created_by: '1'

--- a/config/sync/views.view.bebbo_api_challenges.yml
+++ b/config/sync/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,690 @@
+uuid: e68fcfe0-915b-4717-b5d6-5f750890c852
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - view_custom_table
+_core:
+  default_config_hash: Sln2i8AYkSqZOq3KsKOFxFg47w6UTMTK7t_lzirzYdw
+id: bebbo_api_challenges
+label: Challenges
+module: views
+description: 'Verification challenge nonces.'
+tag: ''
+base_table: bebbo_api_challenges
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Challenges
+      fields:
+        id:
+          id: id
+          table: bebbo_api_challenges
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_challenges
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        challenge:
+          id: challenge
+          table: bebbo_api_challenges
+          field: challenge
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Challenge
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        purpose:
+          id: purpose
+          table: bebbo_api_challenges
+          field: purpose
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Purpose
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        expires:
+          id: expires
+          table: bebbo_api_challenges
+          field: expires
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Expires
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        used:
+          id: used
+          table: bebbo_api_challenges
+          field: used
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Used
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        created:
+          id: created
+          table: bebbo_api_challenges
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_challenges
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        purpose:
+          id: purpose
+          table: bebbo_api_challenges
+          field: purpose
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: purpose_op
+            label: Purpose
+            description: ''
+            use_operator: false
+            operator: purpose_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: purpose
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_challenges
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            challenge: challenge
+            purpose: purpose
+            expires: expires
+            used: used
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            challenge:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            purpose:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            expires:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            used:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/challenges
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.bebbo_api_devices.yml
+++ b/config/sync/views.view.bebbo_api_devices.yml
@@ -1,0 +1,723 @@
+uuid: 224e8d41-6add-4e56-abef-7258a21a75a2
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - view_custom_table
+_core:
+  default_config_hash: jfTdLULSb_ED8p-ggZzaZ19WUJi7ofrG_zOWFDCi8JA
+id: bebbo_api_devices
+label: 'Registered Devices'
+module: views
+description: 'Devices registered for API authentication.'
+tag: ''
+base_table: bebbo_api_devices
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Registered Devices'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_devices
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_devices
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        platform:
+          id: platform
+          table: bebbo_api_devices
+          field: platform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Platform
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        auth_method:
+          id: auth_method
+          table: bebbo_api_devices
+          field: auth_method
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Auth Method'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        status:
+          id: status
+          table: bebbo_api_devices
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        created:
+          id: created
+          table: bebbo_api_devices
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        updated:
+          id: updated
+          table: bebbo_api_devices
+          field: updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_devices
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: bebbo_api_devices
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        platform:
+          id: platform
+          table: bebbo_api_devices
+          field: platform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: platform_op
+            label: Platform
+            description: ''
+            use_operator: false
+            operator: platform_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: platform
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_devices
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            platform: platform
+            auth_method: auth_method
+            status: status
+            created: created
+            updated: updated
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            platform:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            auth_method:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            updated:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/devices
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,649 @@
+uuid: 7b2a9c00-2585-4d00-ba3a-f79b22bab5f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - view_custom_table
+_core:
+  default_config_hash: vu7J4xr_CvjxVa6dSHvDg0utUQOit7RQuaDW71CpWpM
+id: bebbo_api_refresh_tokens
+label: 'Refresh Tokens'
+module: views
+description: 'JWT refresh tokens with rotation tracking.'
+tag: ''
+base_table: bebbo_api_refresh_tokens
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Refresh Tokens'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_refresh_tokens
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_refresh_tokens
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        token_hash:
+          id: token_hash
+          table: bebbo_api_refresh_tokens
+          field: token_hash
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Token Hash'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 12
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        token_family:
+          id: token_family
+          table: bebbo_api_refresh_tokens
+          field: token_family
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Token Family'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        expires:
+          id: expires
+          table: bebbo_api_refresh_tokens
+          field: expires
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Expires
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        revoked:
+          id: revoked
+          table: bebbo_api_refresh_tokens
+          field: revoked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Revoked
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        created:
+          id: created
+          table: bebbo_api_refresh_tokens
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_refresh_tokens
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        device_id:
+          id: device_id
+          table: bebbo_api_refresh_tokens
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            token_hash: token_hash
+            token_family: token_family
+            expires: expires
+            revoked: revoked
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            token_hash:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            token_family:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            expires:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            revoked:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/tokens
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.bebbo_api_security_log.yml
+++ b/config/sync/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,656 @@
+uuid: 4627ff77-5bfc-47f2-abc0-9b3d34e7b3f7
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - view_custom_table
+_core:
+  default_config_hash: LI2MWRjKTeQ_fIbplOs6HzINRI-knG6CGwLg0ETvhbc
+id: bebbo_api_security_log
+label: 'Security Log'
+module: views
+description: 'Security event audit trail.'
+tag: ''
+base_table: bebbo_api_security_log
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Security Log'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_security_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        event_type:
+          id: event_type
+          table: bebbo_api_security_log
+          field: event_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Event Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        device_id:
+          id: device_id
+          table: bebbo_api_security_log
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        ip_address:
+          id: ip_address
+          table: bebbo_api_security_log
+          field: ip_address
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'IP Address'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        details:
+          id: details
+          table: bebbo_api_security_log
+          field: details
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Details
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 120
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        created:
+          id: created
+          table: bebbo_api_security_log
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_security_log
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        event_type:
+          id: event_type
+          table: bebbo_api_security_log
+          field: event_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: event_type_op
+            label: 'Event Type'
+            description: ''
+            use_operator: false
+            operator: event_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: event_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_security_log
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        ip_address:
+          id: ip_address
+          table: bebbo_api_security_log
+          field: ip_address
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ip_address_op
+            label: 'IP Address'
+            description: ''
+            use_operator: false
+            operator: ip_address_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ip_address
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            event_type: event_type
+            device_id: device_id
+            ip_address: ip_address
+            details: details
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            event_type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            ip_address:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            details:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/security-log
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.info.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.info.yml
@@ -1,0 +1,9 @@
+name: Bebbo API Security
+description: 'Device attestation and JWT authentication for V2 API endpoints.'
+type: module
+package: Custom
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:key
+  - drupal:views
+  - view_custom_table:view_custom_table

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.install
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.install
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * @file
+ * Install, schema, and update hooks for bebbo_api_security module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function bebbo_api_security_schema(): array {
+  $schema['bebbo_api_devices'] = [
+    'description' => 'Registered devices for API authentication.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'device_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'platform' => [
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+      ],
+      'auth_method' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'public_key' => [
+        'type' => 'text',
+        'size' => 'medium',
+        'not null' => FALSE,
+      ],
+      'apple_key_id' => [
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+      ],
+      'apple_receipt' => [
+        'type' => 'blob',
+        'size' => 'big',
+        'not null' => FALSE,
+      ],
+      'apple_counter' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'status' => [
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+        'default' => 'active',
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'updated' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'unique keys' => [
+      'device_id' => ['device_id'],
+    ],
+    'indexes' => [
+      'idx_device_platform' => ['device_id', 'platform'],
+      'idx_apple_key_id' => ['apple_key_id'],
+      'idx_status' => ['status'],
+    ],
+  ];
+
+  $schema['bebbo_api_refresh_tokens'] = [
+    'description' => 'Hashed refresh tokens with family-based rotation.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'device_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'token_hash' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+      ],
+      'token_family' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+      ],
+      'expires' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'revoked' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'unique keys' => [
+      'token_hash' => ['token_hash'],
+    ],
+    'indexes' => [
+      'idx_device_expires' => ['device_id', 'expires'],
+      'idx_family' => ['token_family'],
+    ],
+  ];
+
+  $schema['bebbo_api_challenges'] = [
+    'description' => 'Challenge nonces for device verification.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'device_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'challenge' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => TRUE,
+      ],
+      'purpose' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'expires' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'used' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'unique keys' => [
+      'challenge' => ['challenge'],
+    ],
+    'indexes' => [
+      'idx_device_purpose' => ['device_id', 'purpose'],
+    ],
+  ];
+
+  $schema['bebbo_api_security_log'] = [
+    'description' => 'Security event audit trail.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'device_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ],
+      'event_type' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'details' => [
+        'type' => 'text',
+        'size' => 'medium',
+        'not null' => FALSE,
+      ],
+      'ip_address' => [
+        'type' => 'varchar',
+        'length' => 45,
+        'not null' => TRUE,
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'idx_event_type' => ['event_type'],
+      'idx_created' => ['created'],
+    ],
+  ];
+
+  return $schema;
+}
+
+/**
+ * Install API security admin Views configuration.
+ */
+function bebbo_api_security_update_10001(): string {
+  \Drupal::service('config.installer')
+    ->installDefaultConfig('module', 'bebbo_api_security');
+  return 'Installed API security admin Views.';
+}

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.links.menu.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.links.menu.yml
@@ -1,0 +1,6 @@
+bebbo_api_security.settings:
+  title: 'API Security'
+  route_name: bebbo_api_security.settings
+  parent: pb_custom_form.admin_config_parent_buddy
+  description: 'Configure device attestation and JWT authentication for V2 API endpoints.'
+  weight: 110

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.links.task.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.links.task.yml
@@ -1,0 +1,28 @@
+bebbo_api_security.settings_tab:
+  title: 'Settings'
+  route_name: bebbo_api_security.settings
+  base_route: bebbo_api_security.settings
+
+bebbo_api_security.devices_tab:
+  title: 'Devices'
+  route_name: view.bebbo_api_devices.page_1
+  base_route: bebbo_api_security.settings
+  weight: 1
+
+bebbo_api_security.tokens_tab:
+  title: 'Tokens'
+  route_name: view.bebbo_api_refresh_tokens.page_1
+  base_route: bebbo_api_security.settings
+  weight: 2
+
+bebbo_api_security.security_log_tab:
+  title: 'Security Log'
+  route_name: view.bebbo_api_security_log.page_1
+  base_route: bebbo_api_security.settings
+  weight: 3
+
+bebbo_api_security.challenges_tab:
+  title: 'Challenges'
+  route_name: view.bebbo_api_challenges.page_1
+  base_route: bebbo_api_security.settings
+  weight: 4

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.module
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for bebbo_api_security module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function bebbo_api_security_cron(): void {
+  /** @var \Drupal\bebbo_api_security\Service\DeviceRegistryService $registry */
+  $registry = \Drupal::service('bebbo_api_security.device_registry');
+  $logger = \Drupal::logger('bebbo_api_security');
+
+  $stats = $registry->purgeExpired();
+  $total = array_sum($stats);
+
+  if ($total > 0) {
+    $logger->info('Cron cleanup: @challenges challenges, @revoked revoked tokens, @expired expired tokens, @logs log entries purged.', [
+      '@challenges' => $stats['challenges'],
+      '@revoked' => $stats['tokens_revoked'],
+      '@expired' => $stats['tokens_expired'],
+      '@logs' => $stats['logs'],
+    ]);
+  }
+}

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.permissions.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.permissions.yml
@@ -1,0 +1,4 @@
+administer bebbo api security:
+  title: 'Administer Bebbo API security settings'
+  description: 'Configure device attestation, JWT, and enforcement mode for V2 API endpoints.'
+  restrict access: true

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.routing.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.routing.yml
@@ -1,0 +1,64 @@
+bebbo_api_security.settings:
+  path: '/admin/config/parent-buddy/api-security'
+  defaults:
+    _form: '\Drupal\bebbo_api_security\Form\ApiSecuritySettingsForm'
+    _title: 'API Security Settings'
+  requirements:
+    _permission: 'administer bebbo api security'
+  options:
+    _admin_route: TRUE
+
+bebbo_api_security.register:
+  path: '/api/security/register'
+  defaults:
+    _controller: '\Drupal\bebbo_api_security\Controller\SecurityController::register'
+  requirements:
+    # Public endpoint: unauthenticated devices call this to begin attestation.
+    _access: 'TRUE'
+  methods: [POST]
+  options:
+    no_cache: TRUE
+
+bebbo_api_security.device_register:
+  path: '/api/security/device/register'
+  defaults:
+    _controller: '\Drupal\bebbo_api_security\Controller\SecurityController::deviceRegister'
+  requirements:
+    # Public endpoint: sideloaded devices submit their EC public key here.
+    _access: 'TRUE'
+  methods: [POST]
+  options:
+    no_cache: TRUE
+
+bebbo_api_security.device_verify:
+  path: '/api/security/device/verify'
+  defaults:
+    _controller: '\Drupal\bebbo_api_security\Controller\SecurityController::deviceVerify'
+  requirements:
+    # Public endpoint: devices present signed challenge to complete verification.
+    _access: 'TRUE'
+  methods: [POST]
+  options:
+    no_cache: TRUE
+
+bebbo_api_security.refresh:
+  path: '/api/security/refresh'
+  defaults:
+    _controller: '\Drupal\bebbo_api_security\Controller\SecurityController::refresh'
+  requirements:
+    # Public endpoint: clients exchange a refresh token for new access token.
+    _access: 'TRUE'
+  methods: [POST]
+  options:
+    no_cache: TRUE
+
+bebbo_api_security.revoke:
+  path: '/api/security/revoke'
+  defaults:
+    _controller: '\Drupal\bebbo_api_security\Controller\SecurityController::revoke'
+  requirements:
+    # Public endpoint: clients revoke their own device tokens on logout/uninstall.
+    _access: 'TRUE'
+  methods: [POST]
+  options:
+    no_cache: TRUE

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.services.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.services.yml
@@ -1,0 +1,48 @@
+services:
+  logger.channel.bebbo_api_security:
+    parent: logger.channel_base
+    arguments: ['bebbo_api_security']
+
+  bebbo_api_security.device_registry:
+    class: Drupal\bebbo_api_security\Service\DeviceRegistryService
+    arguments:
+      - '@database'
+      - '@logger.channel.bebbo_api_security'
+
+  bebbo_api_security.jwt_service:
+    class: Drupal\bebbo_api_security\Service\JwtService
+    arguments:
+      - '@key.repository'
+      - '@database'
+      - '@config.factory'
+      - '@logger.channel.bebbo_api_security'
+
+  bebbo_api_security.google_play_integrity:
+    class: Drupal\bebbo_api_security\Service\GooglePlayIntegrityService
+    arguments:
+      - '@http_client'
+      - '@key.repository'
+      - '@config.factory'
+      - '@logger.channel.bebbo_api_security'
+
+  bebbo_api_security.apple_app_attest:
+    class: Drupal\bebbo_api_security\Service\AppleAppAttestService
+    arguments:
+      - '@database'
+      - '@config.factory'
+      - '@logger.channel.bebbo_api_security'
+
+  bebbo_api_security.sideloaded_verification:
+    class: Drupal\bebbo_api_security\Service\SideloadedVerificationService
+    arguments:
+      - '@database'
+      - '@logger.channel.bebbo_api_security'
+
+  bebbo_api_security.request_subscriber:
+    class: Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber
+    arguments:
+      - '@bebbo_api_security.jwt_service'
+      - '@config.factory'
+      - '@logger.channel.bebbo_api_security'
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
@@ -1,0 +1,14 @@
+enforcement_mode: disabled
+dev_bypass_enabled: false
+dev_bypass_ips: ''
+google_package_name: ''
+google_project_number: ''
+google_verdict_freshness_seconds: 600
+apple_team_id: ''
+apple_bundle_id: ''
+apple_production_mode: true
+jwt_expiry_seconds: 3600
+refresh_expiry_seconds: 2592000
+refresh_rotation_enabled: true
+register_rate_limit: 10
+refresh_rate_limit: 30

--- a/docroot/modules/custom/bebbo_api_security/config/install/key.key.bebbo_google_sa_key.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/key.key.bebbo_google_sa_key.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {}
+id: bebbo_google_sa_key
+label: 'Google Service Account Key (Play Integrity)'
+description: 'Google Cloud service account JSON key for Play Integrity API verification.'
+key_type: authentication
+key_type_settings: {}
+key_provider: env
+key_provider_settings:
+  env_variable: BEBBO_GOOGLE_SA_KEY
+  base64_encoded: true
+  strip_line_breaks: false
+key_input: none
+key_input_settings: {}

--- a/docroot/modules/custom/bebbo_api_security/config/install/key.key.bebbo_jwt_signing_key.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/key.key.bebbo_jwt_signing_key.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {}
+id: bebbo_jwt_signing_key
+label: 'Bebbo JWT Signing Key (RSA)'
+description: 'RSA-2048 private key for signing JWT tokens. Stored as base64-encoded env var.'
+key_type: authentication
+key_type_settings: {}
+key_provider: env
+key_provider_settings:
+  env_variable: BEBBO_JWT_PRIVATE_KEY
+  base64_encoded: true
+  strip_line_breaks: false
+key_input: none
+key_input_settings: {}

--- a/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_challenges.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_challenges.yml
@@ -1,0 +1,686 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: bebbo_api_challenges
+label: Challenges
+module: views
+description: 'Verification challenge nonces.'
+tag: ''
+base_table: bebbo_api_challenges
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Challenges
+      fields:
+        id:
+          id: id
+          table: bebbo_api_challenges
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_challenges
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        challenge:
+          id: challenge
+          table: bebbo_api_challenges
+          field: challenge
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Challenge
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        purpose:
+          id: purpose
+          table: bebbo_api_challenges
+          field: purpose
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Purpose
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        expires:
+          id: expires
+          table: bebbo_api_challenges
+          field: expires
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Expires
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        used:
+          id: used
+          table: bebbo_api_challenges
+          field: used
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Used
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        created:
+          id: created
+          table: bebbo_api_challenges
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_challenges
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        purpose:
+          id: purpose
+          table: bebbo_api_challenges
+          field: purpose
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: purpose_op
+            label: Purpose
+            description: ''
+            use_operator: false
+            operator: purpose_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: purpose
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_challenges
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            challenge: challenge
+            purpose: purpose
+            expires: expires
+            used: used
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            challenge:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            purpose:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            expires:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            used:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/challenges
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_devices.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_devices.yml
@@ -1,0 +1,719 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: bebbo_api_devices
+label: 'Registered Devices'
+module: views
+description: 'Devices registered for API authentication.'
+tag: ''
+base_table: bebbo_api_devices
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Registered Devices'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_devices
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_devices
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        platform:
+          id: platform
+          table: bebbo_api_devices
+          field: platform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Platform
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        auth_method:
+          id: auth_method
+          table: bebbo_api_devices
+          field: auth_method
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Auth Method'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        status:
+          id: status
+          table: bebbo_api_devices
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        created:
+          id: created
+          table: bebbo_api_devices
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        updated:
+          id: updated
+          table: bebbo_api_devices
+          field: updated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_devices
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: bebbo_api_devices
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        platform:
+          id: platform
+          table: bebbo_api_devices
+          field: platform
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: platform_op
+            label: Platform
+            description: ''
+            use_operator: false
+            operator: platform_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: platform
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_devices
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            platform: platform
+            auth_method: auth_method
+            status: status
+            created: created
+            updated: updated
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            platform:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            auth_method:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            updated:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/devices
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_refresh_tokens.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_refresh_tokens.yml
@@ -1,0 +1,645 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: bebbo_api_refresh_tokens
+label: 'Refresh Tokens'
+module: views
+description: 'JWT refresh tokens with rotation tracking.'
+tag: ''
+base_table: bebbo_api_refresh_tokens
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Refresh Tokens'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_refresh_tokens
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        device_id:
+          id: device_id
+          table: bebbo_api_refresh_tokens
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        token_hash:
+          id: token_hash
+          table: bebbo_api_refresh_tokens
+          field: token_hash
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Token Hash'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 12
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        token_family:
+          id: token_family
+          table: bebbo_api_refresh_tokens
+          field: token_family
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Token Family'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        expires:
+          id: expires
+          table: bebbo_api_refresh_tokens
+          field: expires
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Expires
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        revoked:
+          id: revoked
+          table: bebbo_api_refresh_tokens
+          field: revoked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Revoked
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        created:
+          id: created
+          table: bebbo_api_refresh_tokens
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_refresh_tokens
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        device_id:
+          id: device_id
+          table: bebbo_api_refresh_tokens
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            device_id: device_id
+            token_hash: token_hash
+            token_family: token_family
+            expires: expires
+            revoked: revoked
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            token_hash:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            token_family:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            expires:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            revoked:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/tokens
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_security_log.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/views.view.bebbo_api_security_log.yml
@@ -1,0 +1,652 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: bebbo_api_security_log
+label: 'Security Log'
+module: views
+description: 'Security event audit trail.'
+tag: ''
+base_table: bebbo_api_security_log
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Security Log'
+      fields:
+        id:
+          id: id
+          table: bebbo_api_security_log
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: '#'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        event_type:
+          id: event_type
+          table: bebbo_api_security_log
+          field: event_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Event Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        device_id:
+          id: device_id
+          table: bebbo_api_security_log
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'Device ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        ip_address:
+          id: ip_address
+          table: bebbo_api_security_log
+          field: ip_address
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: 'IP Address'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        details:
+          id: details
+          table: bebbo_api_security_log
+          field: details
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          label: Details
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 120
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        created:
+          id: created
+          table: bebbo_api_security_log
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: numeric
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer bebbo api security'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No records found.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: bebbo_api_security_log
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        event_type:
+          id: event_type
+          table: bebbo_api_security_log
+          field: event_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: event_type_op
+            label: 'Event Type'
+            description: ''
+            use_operator: false
+            operator: event_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: event_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        device_id:
+          id: device_id
+          table: bebbo_api_security_log
+          field: device_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: device_id_op
+            label: 'Device ID'
+            description: ''
+            use_operator: false
+            operator: device_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: device_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        ip_address:
+          id: ip_address
+          table: bebbo_api_security_log
+          field: ip_address
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ip_address_op
+            label: 'IP Address'
+            description: ''
+            use_operator: false
+            operator: ip_address_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ip_address
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            id: id
+            event_type: event_type
+            device_id: device_id
+            ip_address: ip_address
+            details: details
+            created: created
+          default: created
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            event_type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            device_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            ip_address:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            details:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      link_display: ''
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/parent-buddy/api-security/security-log
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: main
+        parent: ''
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
@@ -1,0 +1,46 @@
+bebbo_api_security.settings:
+  type: config_object
+  label: 'Bebbo API Security Settings'
+  mapping:
+    enforcement_mode:
+      type: string
+      label: 'Enforcement mode (disabled, grace_period, enforced)'
+    dev_bypass_enabled:
+      type: boolean
+      label: 'Developer bypass enabled'
+    dev_bypass_ips:
+      type: string
+      label: 'Developer bypass IPs (newline-separated)'
+    google_package_name:
+      type: string
+      label: 'Google Play package name'
+    google_project_number:
+      type: string
+      label: 'Google Cloud project number'
+    google_verdict_freshness_seconds:
+      type: integer
+      label: 'Google verdict freshness window (seconds)'
+    apple_team_id:
+      type: string
+      label: 'Apple Team ID'
+    apple_bundle_id:
+      type: string
+      label: 'Apple Bundle ID'
+    apple_production_mode:
+      type: boolean
+      label: 'Apple production mode'
+    jwt_expiry_seconds:
+      type: integer
+      label: 'JWT expiry in seconds'
+    refresh_expiry_seconds:
+      type: integer
+      label: 'Refresh token expiry in seconds'
+    refresh_rotation_enabled:
+      type: boolean
+      label: 'Refresh token rotation enabled'
+    register_rate_limit:
+      type: integer
+      label: 'Registration rate limit per device per hour'
+    refresh_rate_limit:
+      type: integer
+      label: 'Refresh rate limit per device per hour'

--- a/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Controller;
+
+use Drupal\bebbo_api_security\Service\AppleAppAttestService;
+use Drupal\bebbo_api_security\Service\DeviceRegistryService;
+use Drupal\bebbo_api_security\Service\GooglePlayIntegrityService;
+use Drupal\bebbo_api_security\Service\JwtService;
+use Drupal\bebbo_api_security\Service\SideloadedVerificationService;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Flood\FloodInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * REST endpoints for device registration, verification, and token management.
+ */
+class SecurityController extends ControllerBase {
+
+  /**
+   * Constructs a SecurityController.
+   *
+   * @param \Drupal\bebbo_api_security\Service\GooglePlayIntegrityService $googleService
+   *   Google Play Integrity verification service.
+   * @param \Drupal\bebbo_api_security\Service\AppleAppAttestService $appleService
+   *   Apple App Attest verification service.
+   * @param \Drupal\bebbo_api_security\Service\SideloadedVerificationService $sideloadedService
+   *   Sideloaded device verification service.
+   * @param \Drupal\bebbo_api_security\Service\JwtService $jwtService
+   *   JWT creation and validation service.
+   * @param \Drupal\bebbo_api_security\Service\DeviceRegistryService $registry
+   *   Device registry service.
+   * @param \Drupal\Core\Flood\FloodInterface $flood
+   *   Flood control service.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Logger channel.
+   */
+  public function __construct(
+    protected readonly GooglePlayIntegrityService $googleService,
+    protected readonly AppleAppAttestService $appleService,
+    protected readonly SideloadedVerificationService $sideloadedService,
+    protected readonly JwtService $jwtService,
+    protected readonly DeviceRegistryService $registry,
+    protected readonly FloodInterface $flood,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('bebbo_api_security.google_play_integrity'),
+      $container->get('bebbo_api_security.apple_app_attest'),
+      $container->get('bebbo_api_security.sideloaded_verification'),
+      $container->get('bebbo_api_security.jwt_service'),
+      $container->get('bebbo_api_security.device_registry'),
+      $container->get('flood'),
+      $container->get('logger.channel.bebbo_api_security'),
+    );
+  }
+
+  /**
+   * POST /api/security/register -- Store build attestation (Android/iOS).
+   */
+  public function register(Request $request): JsonResponse {
+    $body = $this->validateRequestBody($request, ['platform', 'device_id']);
+    if ($body instanceof JsonResponse) {
+      return $body;
+    }
+
+    $platform = $body['platform'];
+    $device_id = $body['device_id'];
+    $ip = $request->getClientIp() ?? '0.0.0.0';
+
+    $rate_error = $this->rateLimit($device_id, 'bebbo_register', 10, 3600);
+    if ($rate_error) {
+      return $rate_error;
+    }
+
+    try {
+      if ($platform === 'android') {
+        if (empty($body['integrity_token'])) {
+          return new JsonResponse([
+            'error' => 'missing_field',
+            'message' => 'integrity_token is required for Android.',
+          ], 400);
+        }
+        $this->googleService->verifyToken($body['integrity_token'], $device_id);
+        $auth_method = 'play_integrity';
+
+        $this->registry->registerDevice([
+          'device_id' => $device_id,
+          'platform' => 'android',
+          'auth_method' => $auth_method,
+          'status' => 'active',
+          'created' => time(),
+          'updated' => time(),
+        ]);
+      }
+      elseif ($platform === 'ios') {
+        foreach (['key_id', 'attestation_object', 'client_data_hash'] as $field) {
+          if (empty($body[$field])) {
+            return new JsonResponse([
+              'error' => 'missing_field',
+              'message' => "{$field} is required for iOS.",
+            ], 400);
+          }
+        }
+
+        $public_key = $this->appleService->verifyAttestation(
+          $body['attestation_object'],
+          $body['key_id'],
+          $body['client_data_hash'],
+          $device_id
+        );
+        $auth_method = 'app_attest';
+
+        $this->registry->registerDevice([
+          'device_id' => $device_id,
+          'platform' => 'ios',
+          'auth_method' => $auth_method,
+          'public_key' => $public_key,
+          'apple_key_id' => $body['key_id'],
+          'apple_counter' => 0,
+          'status' => 'active',
+          'created' => time(),
+          'updated' => time(),
+        ]);
+      }
+      else {
+        return new JsonResponse([
+          'error' => 'invalid_platform',
+          'message' => 'Platform must be android or ios.',
+        ], 400);
+      }
+    }
+    catch (\RuntimeException $e) {
+      $this->registry->logSecurityEvent('attest_fail', $device_id, $ip, [
+        'platform' => $platform,
+        'reason' => $e->getMessage(),
+      ]);
+      return new JsonResponse([
+        'status' => 'rejected',
+        'reason' => 'device_integrity_failed',
+        'message' => $e->getMessage(),
+      ], 403);
+    }
+
+    $this->registry->logSecurityEvent('register', $device_id, $ip, [
+      'platform' => $platform,
+    ]);
+
+    return $this->buildTokenResponse($device_id, $platform, $auth_method);
+  }
+
+  /**
+   * POST /api/security/device/register -- Sideloaded step 1: issue challenge.
+   */
+  public function deviceRegister(Request $request): JsonResponse {
+    $body = $this->validateRequestBody($request, ['device_id', 'public_key']);
+    if ($body instanceof JsonResponse) {
+      return $body;
+    }
+
+    $ip = $request->getClientIp() ?? '0.0.0.0';
+    $rate_error = $this->rateLimit($ip, 'bebbo_device_register', 5, 3600);
+    if ($rate_error) {
+      return $rate_error;
+    }
+
+    try {
+      $challenge = $this->sideloadedService->registerDevice(
+        $body['device_id'],
+        $body['public_key']
+      );
+    }
+    catch (\InvalidArgumentException $e) {
+      return new JsonResponse([
+        'error' => 'invalid_key',
+        'message' => $e->getMessage(),
+      ], 400);
+    }
+
+    return new JsonResponse([
+      'status' => 'challenge_issued',
+      'challenge' => $challenge,
+      'expires_in' => 120,
+    ]);
+  }
+
+  /**
+   * POST /api/security/device/verify -- Sideloaded step 2: verify signature.
+   */
+  public function deviceVerify(Request $request): JsonResponse {
+    $body = $this->validateRequestBody($request, [
+      'device_id',
+      'challenge',
+      'signature',
+    ]);
+    if ($body instanceof JsonResponse) {
+      return $body;
+    }
+
+    $device_id = $body['device_id'];
+    $ip = $request->getClientIp() ?? '0.0.0.0';
+
+    $rate_error = $this->rateLimit($device_id, 'bebbo_device_verify', 10, 3600);
+    if ($rate_error) {
+      return $rate_error;
+    }
+
+    try {
+      $valid = $this->sideloadedService->verify(
+        $device_id,
+        $body['challenge'],
+        $body['signature']
+      );
+    }
+    catch (\RuntimeException $e) {
+      $this->registry->logSecurityEvent('attest_fail', $device_id, $ip, [
+        'platform' => 'sideloaded',
+        'reason' => $e->getMessage(),
+      ]);
+      return new JsonResponse([
+        'status' => 'rejected',
+        'reason' => 'verification_failed',
+        'message' => $e->getMessage(),
+      ], 403);
+    }
+
+    if (!$valid) {
+      $this->registry->logSecurityEvent('attest_fail', $device_id, $ip, [
+        'platform' => 'sideloaded',
+        'reason' => 'signature_invalid',
+      ]);
+      return new JsonResponse([
+        'status' => 'rejected',
+        'reason' => 'signature_invalid',
+        'message' => 'Challenge signature verification failed.',
+      ], 403);
+    }
+
+    $this->registry->logSecurityEvent('register', $device_id, $ip, [
+      'platform' => 'sideloaded',
+    ]);
+
+    return $this->buildTokenResponse($device_id, 'sideloaded', 'challenge_response');
+  }
+
+  /**
+   * POST /api/security/refresh -- Token refresh with rotation.
+   */
+  public function refresh(Request $request): JsonResponse {
+    $body = $this->validateRequestBody($request, ['refresh_token']);
+    if ($body instanceof JsonResponse) {
+      return $body;
+    }
+
+    $result = $this->jwtService->refreshTokens($body['refresh_token']);
+    if (!$result) {
+      return new JsonResponse([
+        'status' => 'invalid',
+        'message' => 'Refresh token expired or revoked. Re-attestation required.',
+      ], 401);
+    }
+
+    return new JsonResponse([
+      'status' => 'refreshed',
+      'access_token' => $result['access_token'],
+      'token_type' => 'Bearer',
+      'expires_in' => $result['expires_in'],
+      'refresh_token' => $result['refresh_token'],
+    ]);
+  }
+
+  /**
+   * POST /api/security/revoke -- Revoke refresh tokens for a device.
+   */
+  public function revoke(Request $request): JsonResponse {
+    $token = $this->extractBearerToken($request);
+    if (!$token) {
+      return new JsonResponse([
+        'error' => 'missing_token',
+        'message' => 'Authorization header required.',
+      ], 401);
+    }
+
+    $payload = $this->jwtService->validateToken($token);
+    if (!$payload) {
+      return new JsonResponse([
+        'error' => 'invalid_token',
+        'message' => 'Invalid or expired JWT.',
+      ], 401);
+    }
+
+    $device_id = $payload['sub'];
+    $count = $this->jwtService->revokeTokensForDevice($device_id);
+    $ip = $request->getClientIp() ?? '0.0.0.0';
+    $this->registry->logSecurityEvent('revoke', $device_id, $ip, [
+      'tokens_revoked' => $count,
+    ]);
+
+    return new JsonResponse(['status' => 'revoked']);
+  }
+
+  /**
+   * Decode and validate JSON request body.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The HTTP request.
+   * @param array $required
+   *   Required field names.
+   *
+   * @return array|\Symfony\Component\HttpFoundation\JsonResponse
+   *   Decoded body array, or error response.
+   */
+  private function validateRequestBody(Request $request, array $required): array|JsonResponse {
+    $body = json_decode($request->getContent(), TRUE);
+    if (!is_array($body)) {
+      return new JsonResponse([
+        'error' => 'invalid_json',
+        'message' => 'Request body must be valid JSON.',
+      ], 400);
+    }
+
+    foreach ($required as $field) {
+      if (empty($body[$field])) {
+        return new JsonResponse([
+          'error' => 'missing_field',
+          'message' => "Field '{$field}' is required.",
+        ], 400);
+      }
+    }
+
+    return $body;
+  }
+
+  /**
+   * Build standard token response after successful registration.
+   *
+   * @param string $device_id
+   *   Device identifier.
+   * @param string $platform
+   *   Platform name.
+   * @param string $auth_method
+   *   Authentication method used.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   Token response.
+   */
+  private function buildTokenResponse(string $device_id, string $platform, string $auth_method): JsonResponse {
+    $jwt = $this->jwtService->createToken($device_id, $platform, $auth_method);
+    $refresh = $this->jwtService->createRefreshToken($device_id);
+    $config = $this->config('bebbo_api_security.settings');
+    $expiry = (int) $config->get('jwt_expiry_seconds') ?: 3600;
+
+    return new JsonResponse([
+      'status' => 'verified',
+      'access_token' => $jwt,
+      'token_type' => 'Bearer',
+      'expires_in' => $expiry,
+      'refresh_token' => $refresh['token'],
+    ]);
+  }
+
+  /**
+   * Check flood control. Returns error response or NULL if allowed.
+   *
+   * @param string $identifier
+   *   Flood identifier (device_id or IP).
+   * @param string $event
+   *   Flood event name.
+   * @param int $threshold
+   *   Max requests allowed.
+   * @param int $window
+   *   Time window in seconds.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse|null
+   *   Error response if rate limited, NULL if allowed.
+   */
+  private function rateLimit(string $identifier, string $event, int $threshold, int $window): ?JsonResponse {
+    if (!$this->flood->isAllowed($event, $threshold, $window, $identifier)) {
+      return new JsonResponse([
+        'error' => 'rate_limited',
+        'message' => 'Too many requests. Try again later.',
+      ], 429);
+    }
+    $this->flood->register($event, $window, $identifier);
+    return NULL;
+  }
+
+  /**
+   * Extract Bearer token from Authorization header.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The HTTP request.
+   *
+   * @return string|null
+   *   The token, or NULL if not present.
+   */
+  private function extractBearerToken(Request $request): ?string {
+    $header = $request->headers->get('Authorization', '');
+    if (str_starts_with($header, 'Bearer ')) {
+      return substr($header, 7);
+    }
+    return NULL;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/EventSubscriber/ApiSecuritySubscriber.php
+++ b/docroot/modules/custom/bebbo_api_security/src/EventSubscriber/ApiSecuritySubscriber.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\EventSubscriber;
+
+use Drupal\bebbo_api_security\Service\JwtService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * JWT validation on protected API routes.
+ */
+class ApiSecuritySubscriber implements EventSubscriberInterface {
+
+  private const PROTECTED_PATTERNS = [
+    '#^/v2/api/#',
+    '#^/api/check-update/#',
+  ];
+
+  private const EXCLUDED_PATTERNS = [
+    '#^/api/security/#',
+  ];
+
+  public function __construct(
+    protected readonly JwtService $jwtService,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [KernelEvents::REQUEST => ['onRequest', 300]];
+  }
+
+  /**
+   * Validate JWT on protected API routes based on enforcement mode.
+   */
+  public function onRequest(RequestEvent $event): void {
+    $request = $event->getRequest();
+    $path = $request->getPathInfo();
+
+    if (!$this->isProtectedPath($path)) {
+      return;
+    }
+
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $mode = $config->get('enforcement_mode') ?? 'disabled';
+
+    if ($mode === 'disabled') {
+      return;
+    }
+
+    if ($this->isDevBypass($request)) {
+      return;
+    }
+
+    $token = $this->extractBearerToken($request);
+
+    if ($mode === 'grace_period') {
+      $this->handleGracePeriod($request, $token, $path);
+      return;
+    }
+
+    // Enforced mode.
+    if (!$token) {
+      $event->setResponse($this->buildUnauthorizedResponse(
+        'missing_token',
+        'A valid JWT token is required to access this resource.'
+      ));
+      return;
+    }
+
+    $payload = $this->jwtService->validateToken($token);
+    if (!$payload) {
+      $event->setResponse($this->buildUnauthorizedResponse(
+        'invalid_token',
+        'The provided JWT token is invalid or expired.'
+      ));
+      return;
+    }
+
+    $request->attributes->set('bebbo_device_id', $payload['sub']);
+  }
+
+  /**
+   * Check if a path should be protected by JWT validation.
+   */
+  private function isProtectedPath(string $path): bool {
+    foreach (self::EXCLUDED_PATTERNS as $pattern) {
+      if (preg_match($pattern, $path)) {
+        return FALSE;
+      }
+    }
+    foreach (self::PROTECTED_PATTERNS as $pattern) {
+      if (preg_match($pattern, $path)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Handle grace period mode — log but always allow through.
+   */
+  private function handleGracePeriod(Request $request, ?string $token, string $path): void {
+    if (!$token) {
+      return;
+    }
+
+    $payload = $this->jwtService->validateToken($token);
+    if ($payload) {
+      $request->attributes->set('bebbo_device_id', $payload['sub']);
+    }
+    else {
+      $this->logger->warning('Invalid JWT in grace period from @ip for @path', [
+        '@ip' => $request->getClientIp(),
+        '@path' => $path,
+      ]);
+    }
+  }
+
+  /**
+   * Check if the request IP is in the dev bypass list.
+   */
+  private function isDevBypass(Request $request): bool {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    if (!$config->get('dev_bypass_enabled')) {
+      return FALSE;
+    }
+    $allowed_ips = array_filter(array_map('trim',
+      explode("\n", $config->get('dev_bypass_ips') ?? '')
+    ));
+    return in_array($request->getClientIp(), $allowed_ips, TRUE);
+  }
+
+  /**
+   * Extract Bearer token from Authorization header.
+   */
+  private function extractBearerToken(Request $request): ?string {
+    $header = $request->headers->get('Authorization', '');
+    if (str_starts_with($header, 'Bearer ')) {
+      return substr($header, 7);
+    }
+    return NULL;
+  }
+
+  /**
+   * Build a 401 JSON response with WWW-Authenticate header.
+   */
+  private function buildUnauthorizedResponse(string $error, string $description): JsonResponse {
+    $response = new JsonResponse([
+      'error' => $error,
+      'error_description' => $description,
+    ], 401);
+    $response->headers->set('WWW-Authenticate', 'Bearer realm="Bebbo API"');
+    return $response;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Admin configuration form for API security settings.
+ */
+class ApiSecuritySettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['bebbo_api_security.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'bebbo_api_security_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('bebbo_api_security.settings');
+
+    // Enforcement Mode.
+    $form['enforcement'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Enforcement Mode'),
+      '#open' => TRUE,
+    ];
+    $form['enforcement']['enforcement_mode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Mode'),
+      '#options' => [
+        'disabled' => $this->t('Disabled — no JWT checking'),
+        'grace_period' => $this->t('Grace period — log but allow all requests'),
+        'enforced' => $this->t('Enforced — reject requests without valid JWT'),
+      ],
+      '#default_value' => $config->get('enforcement_mode'),
+    ];
+    $form['enforcement']['dev_bypass_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable developer bypass'),
+      '#description' => $this->t('Allow specific IPs to skip JWT validation.'),
+      '#default_value' => $config->get('dev_bypass_enabled'),
+    ];
+    $form['enforcement']['dev_bypass_ips'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Bypass IP addresses'),
+      '#description' => $this->t('One IP per line. These IPs skip JWT validation.'),
+      '#default_value' => $config->get('dev_bypass_ips'),
+      '#states' => [
+        'visible' => [
+          ':input[name="dev_bypass_enabled"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    // Google Play Integrity.
+    $form['google'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Google Play Integrity'),
+    ];
+    $form['google']['google_package_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Package name'),
+      '#description' => $this->t('Android app package name (e.g., org.unicef.bebbo).'),
+      '#default_value' => $config->get('google_package_name'),
+    ];
+    $form['google']['google_project_number'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Project number'),
+      '#description' => $this->t('Google Cloud project number.'),
+      '#default_value' => $config->get('google_project_number'),
+    ];
+    $form['google']['google_verdict_freshness_seconds'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Verdict freshness (seconds)'),
+      '#description' => $this->t('Maximum age of an integrity verdict.'),
+      '#default_value' => $config->get('google_verdict_freshness_seconds'),
+      '#min' => 60,
+      '#max' => 3600,
+    ];
+
+    // Apple App Attest.
+    $form['apple'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Apple App Attest'),
+    ];
+    $form['apple']['apple_team_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Team ID'),
+      '#description' => $this->t('10-character alphanumeric Apple Team ID.'),
+      '#default_value' => $config->get('apple_team_id'),
+      '#maxlength' => 10,
+    ];
+    $form['apple']['apple_bundle_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Bundle ID'),
+      '#description' => $this->t('iOS app bundle identifier.'),
+      '#default_value' => $config->get('apple_bundle_id'),
+    ];
+    $form['apple']['apple_production_mode'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Production mode'),
+      '#description' => $this->t('Uncheck for development/sandbox testing.'),
+      '#default_value' => $config->get('apple_production_mode'),
+    ];
+
+    // Token Lifetimes.
+    $form['tokens'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Token Lifetimes'),
+    ];
+    $form['tokens']['jwt_expiry_seconds'] = [
+      '#type' => 'number',
+      '#title' => $this->t('JWT expiry (seconds)'),
+      '#default_value' => $config->get('jwt_expiry_seconds'),
+      '#min' => 300,
+      '#max' => 86400,
+    ];
+    $form['tokens']['refresh_expiry_seconds'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Refresh token expiry (seconds)'),
+      '#default_value' => $config->get('refresh_expiry_seconds'),
+      '#min' => 86400,
+      '#max' => 7776000,
+    ];
+    $form['tokens']['refresh_rotation_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable refresh token rotation'),
+      '#description' => $this->t('Issue new refresh token on each use. Recommended for security.'),
+      '#default_value' => $config->get('refresh_rotation_enabled'),
+    ];
+
+    // Rate Limiting.
+    $form['rate_limiting'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Rate Limiting'),
+    ];
+    $form['rate_limiting']['register_rate_limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Registration limit (per device per hour)'),
+      '#default_value' => $config->get('register_rate_limit'),
+      '#min' => 1,
+      '#max' => 100,
+    ];
+    $form['rate_limiting']['refresh_rate_limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Refresh limit (per device per hour)'),
+      '#default_value' => $config->get('refresh_rate_limit'),
+      '#min' => 1,
+      '#max' => 200,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $team_id = $form_state->getValue('apple_team_id');
+    if (!empty($team_id) && !preg_match('/^[A-Z0-9]{10}$/', $team_id)) {
+      $form_state->setErrorByName('apple_team_id', $this->t('Apple Team ID must be 10 alphanumeric characters.'));
+    }
+
+    $bypass_ips = $form_state->getValue('dev_bypass_ips');
+    if (!empty($bypass_ips)) {
+      foreach (array_filter(array_map('trim', explode("\n", $bypass_ips))) as $ip) {
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+          $form_state->setErrorByName('dev_bypass_ips', $this->t('@ip is not a valid IP address.', ['@ip' => $ip]));
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', $form_state->getValue('enforcement_mode'))
+      ->set('dev_bypass_enabled', (bool) $form_state->getValue('dev_bypass_enabled'))
+      ->set('dev_bypass_ips', $form_state->getValue('dev_bypass_ips'))
+      ->set('google_package_name', $form_state->getValue('google_package_name'))
+      ->set('google_project_number', $form_state->getValue('google_project_number'))
+      ->set('google_verdict_freshness_seconds', (int) $form_state->getValue('google_verdict_freshness_seconds'))
+      ->set('apple_team_id', $form_state->getValue('apple_team_id'))
+      ->set('apple_bundle_id', $form_state->getValue('apple_bundle_id'))
+      ->set('apple_production_mode', (bool) $form_state->getValue('apple_production_mode'))
+      ->set('jwt_expiry_seconds', (int) $form_state->getValue('jwt_expiry_seconds'))
+      ->set('refresh_expiry_seconds', (int) $form_state->getValue('refresh_expiry_seconds'))
+      ->set('refresh_rotation_enabled', (bool) $form_state->getValue('refresh_rotation_enabled'))
+      ->set('register_rate_limit', (int) $form_state->getValue('register_rate_limit'))
+      ->set('refresh_rate_limit', (int) $form_state->getValue('refresh_rate_limit'))
+      ->save();
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Service/AppleAppAttestService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/AppleAppAttestService.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Service;
+
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\Normalizable;
+use CBOR\OtherObject\OtherObjectManager;
+use CBOR\StringStream;
+use CBOR\Tag\TagManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Apple App Attest verification for iOS store builds.
+ */
+class AppleAppAttestService {
+
+  private const AAGUID_PRODUCTION = "appattest\x00\x00\x00\x00\x00\x00\x00";
+
+  private const AAGUID_DEVELOPMENT = "appattestdevelop";
+
+  // @codingStandardsIgnoreStart
+  private const APPLE_ROOT_CA_PEM = <<<'PEM'
+-----BEGIN CERTIFICATE-----
+MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
+JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
+QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
+Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
+biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
+bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
+NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDnzczMhM7Q8F2Iv+vha1sJQo/GKF6MIgcDm
+ouxUBEezky0IX5b+8/PCjR3TJQr90U0qo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0G
+A1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYwCgYI
+KoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn53O5
++FRXgeLhd/U3DGMSr0G7AjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijVoyFr
+aWVIyd/dganmrduC1bmTBGwD
+-----END CERTIFICATE-----
+PEM;
+  // @codingStandardsIgnoreEnd
+
+  /**
+   * Constructs an AppleAppAttestService object.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
+   */
+  public function __construct(
+    protected readonly Connection $database,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Verify an Apple App Attest attestation object (one-time key registration).
+   *
+   * @param string $attestation_b64
+   *   Base64-encoded CBOR attestation object.
+   * @param string $key_id
+   *   App Attest key identifier.
+   * @param string $client_data_hash
+   *   Hex-encoded SHA-256 hash of client data.
+   * @param string $device_id
+   *   Device identifier.
+   *
+   * @return string
+   *   PEM-encoded public key extracted from attestation.
+   *
+   * @throws \RuntimeException
+   *   On verification failure.
+   */
+  public function verifyAttestation(string $attestation_b64, string $key_id, string $client_data_hash, string $device_id): string {
+    $attestation_raw = base64_decode($attestation_b64, TRUE);
+    if ($attestation_raw === FALSE) {
+      throw new \RuntimeException('Invalid base64 attestation object.');
+    }
+
+    $decoder = Decoder::create(TagManager::create(), OtherObjectManager::create());
+    try {
+      $cbor = $decoder->decode(StringStream::create($attestation_raw));
+      $map = $this->normalizeCborObject($cbor);
+    }
+    catch (\Throwable $e) {
+      throw new \RuntimeException('CBOR decode failed: ' . $e->getMessage());
+    }
+
+    $fmt = $map['fmt'] ?? '';
+    if ($fmt !== 'apple-appattest') {
+      throw new \RuntimeException("Unexpected attestation format: {$fmt}");
+    }
+
+    $auth_data = $map['authData'] ?? '';
+    if (!is_string($auth_data) || strlen($auth_data) < 55) {
+      throw new \RuntimeException('authData too short or invalid.');
+    }
+
+    $parsed = $this->parseAuthData($auth_data);
+
+    // Verify RP ID hash.
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $team_id = $config->get('apple_team_id');
+    $bundle_id = $config->get('apple_bundle_id');
+    $expected_rp_hash = hash('sha256', "{$team_id}.{$bundle_id}", TRUE);
+
+    if (!hash_equals($expected_rp_hash, $parsed['rp_id_hash'])) {
+      throw new \RuntimeException('RP ID hash mismatch. Check Apple Team ID and Bundle ID.');
+    }
+
+    // Verify AAGUID.
+    $production = (bool) $config->get('apple_production_mode');
+    $expected_aaguid = $production ? self::AAGUID_PRODUCTION : self::AAGUID_DEVELOPMENT;
+    if ($parsed['aaguid'] !== $expected_aaguid) {
+      throw new \RuntimeException('AAGUID mismatch. Check apple_production_mode setting.');
+    }
+
+    // Verify credential ID matches key_id.
+    if ($parsed['credential_id'] !== base64_decode($key_id, TRUE)) {
+      throw new \RuntimeException('Credential ID does not match key_id.');
+    }
+
+    // Verify counter is 0 for attestation.
+    if ($parsed['counter'] !== 0) {
+      throw new \RuntimeException('Counter must be 0 for attestation.');
+    }
+
+    // Extract and verify certificate chain.
+    $att_stmt = $map['attStmt'] ?? [];
+    $x5c = $att_stmt['x5c'] ?? [];
+    if (count($x5c) < 2) {
+      throw new \RuntimeException('Attestation missing x5c certificate chain.');
+    }
+
+    $leaf_der = $x5c[0];
+    $intermediate_der = $x5c[1];
+
+    $this->verifyCertificateChain($leaf_der, $intermediate_der);
+
+    // Verify nonce in leaf certificate.
+    $nonce = hash('sha256', $auth_data . hex2bin($client_data_hash), TRUE);
+    $this->verifyAttestationNonce($leaf_der, $nonce);
+
+    // Extract public key from COSE key in authData.
+    $public_key_pem = $this->coseKeyToPem($parsed['cose_key_bytes']);
+
+    return $public_key_pem;
+  }
+
+  /**
+   * Verify an App Attest assertion (ongoing request verification).
+   *
+   * @param string $assertion_b64
+   *   Base64-encoded CBOR assertion.
+   * @param string $client_data_hash
+   *   Hex-encoded SHA-256 of client data.
+   * @param string $key_id
+   *   App Attest key identifier.
+   * @param string $stored_public_key
+   *   PEM public key from attestation.
+   * @param int $stored_counter
+   *   Last known counter value.
+   *
+   * @return int
+   *   New counter value (must be stored by caller).
+   *
+   * @throws \RuntimeException
+   *   On verification failure.
+   */
+  public function verifyAssertion(string $assertion_b64, string $client_data_hash, string $key_id, string $stored_public_key, int $stored_counter): int {
+    $assertion_raw = base64_decode($assertion_b64, TRUE);
+    if ($assertion_raw === FALSE) {
+      throw new \RuntimeException('Invalid base64 assertion.');
+    }
+
+    $decoder = Decoder::create(TagManager::create(), OtherObjectManager::create());
+    try {
+      $cbor = $decoder->decode(StringStream::create($assertion_raw));
+      $map = $this->normalizeCborObject($cbor);
+    }
+    catch (\Throwable $e) {
+      throw new \RuntimeException('CBOR decode failed: ' . $e->getMessage());
+    }
+
+    $signature = $map['signature'] ?? '';
+    $authenticator_data = $map['authenticatorData'] ?? '';
+
+    if (!is_string($authenticator_data) || strlen($authenticator_data) < 37) {
+      throw new \RuntimeException('authenticatorData too short.');
+    }
+
+    // Parse authenticator data.
+    $rp_id_hash = substr($authenticator_data, 0, 32);
+    $counter = unpack('N', substr($authenticator_data, 33, 4))[1];
+
+    // Verify RP ID hash.
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $team_id = $config->get('apple_team_id');
+    $bundle_id = $config->get('apple_bundle_id');
+    $expected_rp_hash = hash('sha256', "{$team_id}.{$bundle_id}", TRUE);
+
+    if (!hash_equals($expected_rp_hash, $rp_id_hash)) {
+      throw new \RuntimeException('RP ID hash mismatch in assertion.');
+    }
+
+    // Verify counter is increasing.
+    if ($counter <= $stored_counter) {
+      throw new \RuntimeException("Counter not increasing: got {$counter}, expected > {$stored_counter}");
+    }
+
+    // Verify signature.
+    $nonce = hash('sha256', $authenticator_data . hex2bin($client_data_hash), TRUE);
+    $result = openssl_verify($nonce, $signature, $stored_public_key, OPENSSL_ALGO_SHA256);
+
+    if ($result !== 1) {
+      throw new \RuntimeException('Assertion signature verification failed.');
+    }
+
+    return $counter;
+  }
+
+  /**
+   * Normalize a decoded CBOR object to a PHP array.
+   *
+   * @param \CBOR\CBORObject $object
+   *   The decoded CBOR object.
+   *
+   * @return mixed
+   *   The normalized PHP value (typically an array for maps).
+   *
+   * @throws \RuntimeException
+   *   If the object does not implement Normalizable.
+   */
+  private function normalizeCborObject(CBORObject $object): mixed {
+    if (!$object instanceof Normalizable) {
+      throw new \RuntimeException('CBOR object is not normalizable.');
+    }
+    return $object->normalize();
+  }
+
+  /**
+   * Parse binary authData from attestation object.
+   *
+   * @param string $auth_data
+   *   Raw binary authData.
+   *
+   * @return array
+   *   Keys: rp_id_hash, flags, counter, aaguid, credential_id,
+   *   cose_key_bytes.
+   */
+  private function parseAuthData(string $auth_data): array {
+    $rp_id_hash = substr($auth_data, 0, 32);
+    $flags = ord($auth_data[32]);
+    $counter = unpack('N', substr($auth_data, 33, 4))[1];
+    $aaguid = substr($auth_data, 37, 16);
+    $cred_id_len = unpack('n', substr($auth_data, 53, 2))[1];
+    $credential_id = substr($auth_data, 55, $cred_id_len);
+    $cose_key_bytes = substr($auth_data, 55 + $cred_id_len);
+
+    return [
+      'rp_id_hash' => $rp_id_hash,
+      'flags' => $flags,
+      'counter' => $counter,
+      'aaguid' => $aaguid,
+      'credential_id' => $credential_id,
+      'cose_key_bytes' => $cose_key_bytes,
+    ];
+  }
+
+  /**
+   * Verify the certificate chain: leaf -> intermediate -> Apple Root CA.
+   *
+   * @param string $leaf_der
+   *   DER-encoded leaf certificate.
+   * @param string $intermediate_der
+   *   DER-encoded intermediate certificate.
+   *
+   * @throws \RuntimeException
+   *   If chain verification fails.
+   */
+  private function verifyCertificateChain(string $leaf_der, string $intermediate_der): void {
+    $leaf_pem = $this->derToPem($leaf_der, 'CERTIFICATE');
+    $intermediate_pem = $this->derToPem($intermediate_der, 'CERTIFICATE');
+
+    $leaf_cert = openssl_x509_read($leaf_pem);
+    if (!$leaf_cert) {
+      throw new \RuntimeException('Failed to parse leaf certificate.');
+    }
+
+    $intermediate_cert = openssl_x509_read($intermediate_pem);
+    if (!$intermediate_cert) {
+      throw new \RuntimeException('Failed to parse intermediate certificate.');
+    }
+
+    $root_cert = openssl_x509_read(self::APPLE_ROOT_CA_PEM);
+
+    // Verify leaf is signed by intermediate.
+    $result = openssl_x509_verify($leaf_cert, openssl_pkey_get_public($intermediate_cert));
+    if ($result !== 1) {
+      throw new \RuntimeException('Leaf certificate not signed by intermediate.');
+    }
+
+    // Verify intermediate is signed by Apple Root CA.
+    $result = openssl_x509_verify($intermediate_cert, openssl_pkey_get_public($root_cert));
+    if ($result !== 1) {
+      throw new \RuntimeException('Intermediate certificate not signed by Apple Root CA.');
+    }
+  }
+
+  /**
+   * Extract and verify the nonce from the leaf certificate extension.
+   *
+   * @param string $leaf_der
+   *   DER-encoded leaf certificate.
+   * @param string $expected_nonce
+   *   Binary expected nonce (32 bytes).
+   *
+   * @throws \RuntimeException
+   *   If nonce doesn't match.
+   */
+  private function verifyAttestationNonce(string $leaf_der, string $expected_nonce): void {
+    $leaf_pem = $this->derToPem($leaf_der, 'CERTIFICATE');
+    $parsed = openssl_x509_parse($leaf_pem);
+
+    // OID 1.2.840.113635.100.8.2 contains the nonce.
+    $extensions = $parsed['extensions'] ?? [];
+    $nonce_ext = $extensions['1.2.840.113635.100.8.2'] ?? NULL;
+
+    if ($nonce_ext === NULL) {
+      throw new \RuntimeException('Attestation certificate missing nonce extension (OID 1.2.840.113635.100.8.2).');
+    }
+
+    // The extension value is ASN.1 wrapped. The nonce is the last 32 bytes.
+    $nonce_bytes = substr($nonce_ext, -32);
+
+    if (!hash_equals($expected_nonce, $nonce_bytes)) {
+      throw new \RuntimeException('Attestation nonce mismatch.');
+    }
+  }
+
+  /**
+   * Convert a COSE-encoded EC P-256 public key to PEM format.
+   *
+   * COSE key map: 1=kty(EC2=2), 3=alg, -1=crv(P-256=1), -2=x, -3=y.
+   *
+   * @param string $cose_bytes
+   *   Raw CBOR-encoded COSE key bytes.
+   *
+   * @return string
+   *   PEM-encoded EC P-256 public key.
+   *
+   * @throws \RuntimeException
+   *   If key type unsupported or coordinates invalid.
+   */
+  private function coseKeyToPem(string $cose_bytes): string {
+    $decoder = Decoder::create(TagManager::create(), OtherObjectManager::create());
+    try {
+      $cose = $decoder->decode(StringStream::create($cose_bytes));
+      $map = $this->normalizeCborObject($cose);
+    }
+    catch (\Throwable $e) {
+      throw new \RuntimeException('Failed to decode COSE key: ' . $e->getMessage());
+    }
+
+    $kty = (int) ($map[1] ?? 0);
+    $crv = (int) ($map[-1] ?? 0);
+    $x = $map[-2] ?? NULL;
+    $y = $map[-3] ?? NULL;
+
+    if ($kty !== 2 || $crv !== 1) {
+      throw new \RuntimeException('Unsupported COSE key type. Expected EC2 P-256.');
+    }
+
+    if (!is_string($x) || strlen($x) !== 32 || !is_string($y) || strlen($y) !== 32) {
+      throw new \RuntimeException('Invalid COSE key coordinates.');
+    }
+
+    // Build uncompressed EC point: 0x04 || x || y.
+    $point = "\x04" . $x . $y;
+
+    // Wrap in DER SubjectPublicKeyInfo for P-256.
+    $der = "\x30\x59"
+      . "\x30\x13"
+      . "\x06\x07\x2a\x86\x48\xce\x3d\x02\x01"
+      . "\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07"
+      . "\x03\x42\x00"
+      . $point;
+
+    return "-----BEGIN PUBLIC KEY-----\n"
+      . chunk_split(base64_encode($der), 64, "\n")
+      . "-----END PUBLIC KEY-----\n";
+  }
+
+  /**
+   * Convert DER bytes to PEM format.
+   *
+   * @param string $der
+   *   DER-encoded bytes.
+   * @param string $type
+   *   PEM type label (e.g., 'CERTIFICATE').
+   *
+   * @return string
+   *   PEM-encoded string.
+   */
+  private function derToPem(string $der, string $type): string {
+    return "-----BEGIN {$type}-----\n"
+      . chunk_split(base64_encode($der), 64, "\n")
+      . "-----END {$type}-----\n";
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Service;
+
+use Drupal\Core\Database\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Database operations for device registration, tokens, challenges, and logs.
+ */
+class DeviceRegistryService {
+
+  public function __construct(
+    protected readonly Connection $database,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Insert a new device record.
+   *
+   * @return int
+   *   The auto-increment ID of the inserted row.
+   */
+  public function registerDevice(array $fields): int {
+    return (int) $this->database->insert('bebbo_api_devices')
+      ->fields($fields)
+      ->execute();
+  }
+
+  /**
+   * Fetch a device by device_id.
+   */
+  public function getDevice(string $device_id): ?object {
+    return $this->database->select('bebbo_api_devices', 'd')
+      ->fields('d')
+      ->condition('d.device_id', $device_id)
+      ->execute()
+      ->fetchObject() ?: NULL;
+  }
+
+  /**
+   * Fetch a device by Apple App Attest key ID.
+   */
+  public function getDeviceByAppleKeyId(string $key_id): ?object {
+    return $this->database->select('bebbo_api_devices', 'd')
+      ->fields('d')
+      ->condition('d.apple_key_id', $key_id)
+      ->execute()
+      ->fetchObject() ?: NULL;
+  }
+
+  /**
+   * Update device fields.
+   */
+  public function updateDevice(string $device_id, array $fields): void {
+    $this->database->update('bebbo_api_devices')
+      ->fields($fields)
+      ->condition('device_id', $device_id)
+      ->execute();
+  }
+
+  /**
+   * Set device status to revoked.
+   */
+  public function revokeDevice(string $device_id): void {
+    $this->updateDevice($device_id, [
+      'status' => 'revoked',
+      'updated' => time(),
+    ]);
+  }
+
+  /**
+   * Insert a security event into the audit log.
+   */
+  public function logSecurityEvent(string $event_type, ?string $device_id, string $ip, ?array $details = NULL): void {
+    $this->database->insert('bebbo_api_security_log')
+      ->fields([
+        'device_id' => $device_id,
+        'event_type' => $event_type,
+        'details' => $details ? json_encode($details) : NULL,
+        'ip_address' => $ip,
+        'created' => time(),
+      ])
+      ->execute();
+  }
+
+  /**
+   * Purge expired challenges, revoked tokens, and old log entries.
+   *
+   * @return array
+   *   Counts of purged rows keyed by type.
+   */
+  public function purgeExpired(): array {
+    $now = time();
+    $stats = [];
+
+    $stats['challenges'] = $this->database->delete('bebbo_api_challenges')
+      ->condition('expires', $now, '<')
+      ->execute();
+
+    $stats['tokens_revoked'] = $this->database->delete('bebbo_api_refresh_tokens')
+      ->condition('revoked', 1)
+      ->condition('created', $now - 604800, '<')
+      ->execute();
+
+    $stats['tokens_expired'] = $this->database->delete('bebbo_api_refresh_tokens')
+      ->condition('expires', $now, '<')
+      ->execute();
+
+    $max_id = $this->database->select('bebbo_api_security_log', 'l')
+      ->fields('l', ['id'])
+      ->orderBy('id', 'DESC')
+      ->range(10000, 1)
+      ->execute()
+      ->fetchField();
+
+    $stats['logs'] = 0;
+    if ($max_id) {
+      $stats['logs'] = $this->database->delete('bebbo_api_security_log')
+        ->condition('id', $max_id, '<=')
+        ->execute();
+    }
+
+    return $stats;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Firebase\JWT\JWT;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Google Play Integrity API verification for Android store builds.
+ */
+class GooglePlayIntegrityService {
+
+  /**
+   * Cached Google OAuth2 access token.
+   *
+   * @var string|null
+   */
+  private ?string $googleAccessToken = NULL;
+
+  /**
+   * Unix timestamp when the cached token expires.
+   *
+   * @var int
+   */
+  private int $tokenExpiresAt = 0;
+
+  /**
+   * Constructs a GooglePlayIntegrityService.
+   *
+   * @param \GuzzleHttp\ClientInterface $httpClient
+   *   HTTP client for API requests.
+   * @param \Drupal\key\KeyRepositoryInterface $keyRepository
+   *   Key repository for service account credentials.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory for module settings.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Logger channel.
+   */
+  public function __construct(
+    protected readonly ClientInterface $httpClient,
+    protected readonly KeyRepositoryInterface $keyRepository,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Verify a Play Integrity token from the mobile app.
+   *
+   * @param string $integrity_token
+   *   Opaque token from the app's Play Integrity API call.
+   * @param string $device_id
+   *   Device identifier — used to verify requestHash binding.
+   * @param string|null $expected_request_hash
+   *   Expected base64url-encoded SHA-256 of the nonce the app passed to
+   *   requestIntegrityToken(). If NULL, defaults to SHA-256(device_id).
+   *
+   * @return array
+   *   Decoded token payload with verdicts.
+   *
+   * @throws \RuntimeException
+   *   On verification failure.
+   */
+  public function verifyToken(string $integrity_token, string $device_id, ?string $expected_request_hash = NULL): array {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $package_name = $config->get('google_package_name');
+
+    if (empty($package_name)) {
+      throw new \RuntimeException('Google Play package name not configured.');
+    }
+
+    $access_token = $this->getGoogleAccessToken();
+
+    try {
+      $response = $this->httpClient->request('POST',
+        "https://playintegrity.googleapis.com/v1/{$package_name}:decodeIntegrityToken",
+        [
+          'headers' => [
+            'Authorization' => "Bearer {$access_token}",
+            'Content-Type' => 'application/json',
+          ],
+          'json' => ['integrity_token' => $integrity_token],
+          'timeout' => 10,
+        ]
+      );
+    }
+    catch (GuzzleException $e) {
+      $this->logger->error('Google Play Integrity API error: @msg', [
+        '@msg' => $e->getMessage(),
+      ]);
+      throw new \RuntimeException('Failed to verify integrity token with Google.');
+    }
+
+    $payload = json_decode((string) $response->getBody(), TRUE);
+    if (!$payload) {
+      throw new \RuntimeException('Invalid response from Google Play Integrity API.');
+    }
+
+    if ($expected_request_hash === NULL) {
+      $expected_request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+    }
+
+    $this->verifyVerdicts($payload, $device_id, $expected_request_hash);
+
+    return $payload;
+  }
+
+  /**
+   * Verify the verdicts in a decoded integrity token payload.
+   *
+   * @param array $payload
+   *   Decoded token payload from Google.
+   * @param string $device_id
+   *   Device identifier for error context.
+   * @param string $expected_request_hash
+   *   Base64url-encoded SHA-256 hash the app used as nonce.
+   *
+   * @throws \RuntimeException
+   *   If any verdict check fails.
+   */
+  private function verifyVerdicts(array $payload, string $device_id, string $expected_request_hash): void {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $package_name = $config->get('google_package_name');
+    $freshness = (int) $config->get('google_verdict_freshness_seconds') ?: 600;
+
+    $details = $payload['tokenPayloadExternal'] ?? [];
+
+    // Verify requestHash — binds the integrity token to this registration.
+    $actual_hash = $details['requestDetails']['requestHash'] ?? '';
+    if (!hash_equals($expected_request_hash, $actual_hash)) {
+      throw new \RuntimeException('requestHash mismatch: integrity token not bound to this request.');
+    }
+
+    // Verify package name.
+    $request_package = $details['requestDetails']['requestPackageName'] ?? '';
+    if ($request_package !== $package_name) {
+      throw new \RuntimeException("Package name mismatch: expected {$package_name}, got {$request_package}");
+    }
+
+    // Verify timestamp freshness.
+    $timestamp_ms = (int) ($details['requestDetails']['timestampMillis'] ?? 0);
+    $age_seconds = abs(time() - (int) ($timestamp_ms / 1000));
+    if ($age_seconds > $freshness) {
+      throw new \RuntimeException("Integrity token too old: {$age_seconds}s > {$freshness}s");
+    }
+
+    // Verify device integrity.
+    $device_verdicts = $details['deviceIntegrity']['deviceRecognitionVerdict'] ?? [];
+    if (!in_array('MEETS_DEVICE_INTEGRITY', $device_verdicts, TRUE)) {
+      throw new \RuntimeException(
+        'Device does not meet integrity requirements. Verdicts: '
+        . implode(', ', $device_verdicts)
+      );
+    }
+
+    // Verify app recognition.
+    $app_verdict = $details['appIntegrity']['appRecognitionVerdict'] ?? 'UNEVALUATED';
+    if ($app_verdict !== 'PLAY_RECOGNIZED') {
+      throw new \RuntimeException("App not recognized by Play Store: {$app_verdict}");
+    }
+  }
+
+  /**
+   * Get a Google OAuth2 access token using service account JWT.
+   *
+   * Caches the token for 55 minutes (Google tokens last 1 hour).
+   *
+   * @return string
+   *   OAuth2 access token.
+   *
+   * @throws \RuntimeException
+   *   If key not configured or token exchange fails.
+   */
+  private function getGoogleAccessToken(): string {
+    if ($this->googleAccessToken && time() < $this->tokenExpiresAt) {
+      return $this->googleAccessToken;
+    }
+
+    $key = $this->keyRepository->getKey('bebbo_google_sa_key');
+    if (!$key) {
+      throw new \RuntimeException('Google Service Account key not configured. Check Key entity "bebbo_google_sa_key".');
+    }
+    $sa_json = json_decode($key->getKeyValue(), TRUE);
+    if (!$sa_json || empty($sa_json['client_email']) || empty($sa_json['private_key'])) {
+      throw new \RuntimeException('Invalid Google Service Account JSON. Expected client_email and private_key.');
+    }
+
+    $now = time();
+    $jwt_payload = [
+      'iss' => $sa_json['client_email'],
+      'scope' => 'https://www.googleapis.com/auth/playintegrity',
+      'aud' => 'https://oauth2.googleapis.com/token',
+      'iat' => $now,
+      'exp' => $now + 3600,
+    ];
+
+    $assertion = JWT::encode($jwt_payload, $sa_json['private_key'], 'RS256');
+
+    try {
+      $response = $this->httpClient->request('POST', 'https://oauth2.googleapis.com/token', [
+        'form_params' => [
+          'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          'assertion' => $assertion,
+        ],
+        'timeout' => 10,
+      ]);
+    }
+    catch (GuzzleException $e) {
+      $this->logger->error('Google OAuth2 token exchange failed: @msg', [
+        '@msg' => $e->getMessage(),
+      ]);
+      throw new \RuntimeException('Failed to obtain Google access token.');
+    }
+
+    $token_data = json_decode((string) $response->getBody(), TRUE);
+    if (empty($token_data['access_token'])) {
+      throw new \RuntimeException('Google OAuth2 response missing access_token.');
+    }
+
+    $this->googleAccessToken = $token_data['access_token'];
+    $this->tokenExpiresAt = $now + 3300;
+
+    return $this->googleAccessToken;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Service/JwtService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/JwtService.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\key\KeyRepositoryInterface;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * JWT creation, validation, and refresh token management.
+ */
+class JwtService {
+
+  /**
+   * Cached RSA private key PEM string.
+   *
+   * @var string|null
+   */
+  private ?string $privateKey = NULL;
+
+  /**
+   * Cached RSA public key PEM string.
+   *
+   * @var string|null
+   */
+  private ?string $publicKey = NULL;
+
+  public function __construct(
+    protected readonly KeyRepositoryInterface $keyRepository,
+    protected readonly Connection $database,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Create a signed JWT for a verified device.
+   */
+  public function createToken(string $device_id, string $platform, string $auth_method): string {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $expiry = (int) $config->get('jwt_expiry_seconds') ?: 3600;
+
+    $payload = [
+      'iss' => 'bebbo-cms',
+      'sub' => $device_id,
+      'iat' => time(),
+      'exp' => time() + $expiry,
+      'platform' => $platform,
+      'auth_method' => $auth_method,
+      'jti' => bin2hex(random_bytes(16)),
+    ];
+
+    return JWT::encode($payload, $this->getPrivateKey(), 'RS256');
+  }
+
+  /**
+   * Validate a JWT and return the decoded payload, or NULL on failure.
+   */
+  public function validateToken(string $token): ?array {
+    try {
+      $decoded = JWT::decode($token, new Key($this->getPublicKey(), 'RS256'));
+      return (array) $decoded;
+    }
+    catch (ExpiredException) {
+      return NULL;
+    }
+    catch (SignatureInvalidException) {
+      $this->logger->warning('Invalid JWT signature');
+      return NULL;
+    }
+    catch (\Exception $e) {
+      $this->logger->warning('JWT validation failed: @msg', ['@msg' => $e->getMessage()]);
+      return NULL;
+    }
+  }
+
+  /**
+   * Create a new opaque refresh token and store its hash.
+   *
+   * @return array
+   *   Keys: 'token' (raw opaque string), 'family' (rotation family ID).
+   */
+  public function createRefreshToken(string $device_id): array {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $expiry = (int) $config->get('refresh_expiry_seconds') ?: 2592000;
+
+    $raw_token = bin2hex(random_bytes(32));
+    $family = bin2hex(random_bytes(32));
+    $hash = hash('sha256', $raw_token);
+
+    $this->database->insert('bebbo_api_refresh_tokens')->fields([
+      'device_id' => $device_id,
+      'token_hash' => $hash,
+      'token_family' => $family,
+      'expires' => time() + $expiry,
+      'revoked' => 0,
+      'created' => time(),
+    ])->execute();
+
+    return ['token' => $raw_token, 'family' => $family];
+  }
+
+  /**
+   * Validate and rotate a refresh token. Returns new JWT + refresh token.
+   *
+   * Implements family-based replay detection: if a revoked token is reused,
+   * the entire token family is revoked (compromised session).
+   *
+   * @return array|null
+   *   Keys: access_token, refresh_token, expires_in. NULL on any failure.
+   */
+  public function refreshTokens(string $raw_refresh_token): ?array {
+    $hash = hash('sha256', $raw_refresh_token);
+
+    $row = $this->database->select('bebbo_api_refresh_tokens', 'rt')
+      ->fields('rt')
+      ->condition('rt.token_hash', $hash)
+      ->execute()
+      ->fetchObject();
+
+    if (!$row) {
+      return NULL;
+    }
+
+    if ((int) $row->revoked === 1) {
+      $this->database->update('bebbo_api_refresh_tokens')
+        ->fields(['revoked' => 1])
+        ->condition('token_family', $row->token_family)
+        ->execute();
+      $this->logger->error('Refresh token replay detected for device @device, family @family', [
+        '@device' => $row->device_id,
+        '@family' => $row->token_family,
+      ]);
+      return NULL;
+    }
+
+    if ((int) $row->expires < time()) {
+      return NULL;
+    }
+
+    $this->database->update('bebbo_api_refresh_tokens')
+      ->fields(['revoked' => 1])
+      ->condition('id', $row->id)
+      ->execute();
+
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $expiry = (int) $config->get('refresh_expiry_seconds') ?: 2592000;
+    $new_raw = bin2hex(random_bytes(32));
+    $new_hash = hash('sha256', $new_raw);
+
+    $this->database->insert('bebbo_api_refresh_tokens')->fields([
+      'device_id' => $row->device_id,
+      'token_hash' => $new_hash,
+      'token_family' => $row->token_family,
+      'expires' => time() + $expiry,
+      'revoked' => 0,
+      'created' => time(),
+    ])->execute();
+
+    $device = $this->database->select('bebbo_api_devices', 'd')
+      ->fields('d', ['platform', 'auth_method'])
+      ->condition('d.device_id', $row->device_id)
+      ->execute()
+      ->fetchObject();
+
+    if (!$device) {
+      return NULL;
+    }
+
+    $jwt = $this->createToken($row->device_id, $device->platform, $device->auth_method);
+
+    return [
+      'access_token' => $jwt,
+      'refresh_token' => $new_raw,
+      'expires_in' => (int) $config->get('jwt_expiry_seconds') ?: 3600,
+    ];
+  }
+
+  /**
+   * Revoke all refresh tokens for a device.
+   */
+  public function revokeTokensForDevice(string $device_id): int {
+    return $this->database->update('bebbo_api_refresh_tokens')
+      ->fields(['revoked' => 1])
+      ->condition('device_id', $device_id)
+      ->condition('revoked', 0)
+      ->execute();
+  }
+
+  /**
+   * Load the RSA private key from Key module.
+   */
+  private function getPrivateKey(): string {
+    if ($this->privateKey === NULL) {
+      $key = $this->keyRepository->getKey('bebbo_jwt_signing_key');
+      if (!$key) {
+        throw new \RuntimeException('JWT signing key not configured. Check Key module entity "bebbo_jwt_signing_key".');
+      }
+      $this->privateKey = $key->getKeyValue();
+      if (empty($this->privateKey)) {
+        throw new \RuntimeException('JWT signing key is empty. Check BEBBO_JWT_PRIVATE_KEY environment variable.');
+      }
+    }
+    return $this->privateKey;
+  }
+
+  /**
+   * Derive the public key from the private key.
+   */
+  private function getPublicKey(): string {
+    if ($this->publicKey === NULL) {
+      $private = openssl_pkey_get_private($this->getPrivateKey());
+      if (!$private) {
+        throw new \RuntimeException('Invalid RSA private key.');
+      }
+      $details = openssl_pkey_get_details($private);
+      $this->publicKey = $details['key'];
+    }
+    return $this->publicKey;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/src/Service/SideloadedVerificationService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/SideloadedVerificationService.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\bebbo_api_security\Service;
+
+use Drupal\Core\Database\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Challenge-response verification for sideloaded/enterprise app builds.
+ */
+class SideloadedVerificationService {
+
+  /**
+   * Constructs a SideloadedVerificationService.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
+   */
+  public function __construct(
+    protected readonly Connection $database,
+    protected readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Register a sideloaded device and issue a challenge nonce.
+   *
+   * @param string $device_id
+   *   SHA-256 hashed device identifier.
+   * @param string $public_key_pem
+   *   PEM-encoded EC P-256 public key.
+   *
+   * @return string
+   *   Hex-encoded 32-byte challenge nonce (64 hex chars).
+   *
+   * @throws \InvalidArgumentException
+   *   If the public key is not a valid EC P-256 key.
+   */
+  public function registerDevice(string $device_id, string $public_key_pem): string {
+    $key = openssl_pkey_get_public($public_key_pem);
+    if (!$key) {
+      throw new \InvalidArgumentException('Invalid public key format.');
+    }
+    $details = openssl_pkey_get_details($key);
+    if ($details['type'] !== OPENSSL_KEYTYPE_EC
+      || ($details['ec']['curve_name'] ?? '') !== 'prime256v1') {
+      throw new \InvalidArgumentException('Public key must be EC P-256 (prime256v1).');
+    }
+
+    $this->database->merge('bebbo_api_devices')
+      ->keys(['device_id' => $device_id])
+      ->fields([
+        'platform' => 'sideloaded',
+        'auth_method' => 'challenge_response',
+        'public_key' => $public_key_pem,
+        'status' => 'pending',
+        'created' => time(),
+        'updated' => time(),
+      ])
+      ->execute();
+
+    $challenge = bin2hex(random_bytes(32));
+    $this->database->insert('bebbo_api_challenges')->fields([
+      'device_id' => $device_id,
+      'challenge' => $challenge,
+      'purpose' => 'sideloaded_verify',
+      'expires' => time() + 120,
+      'used' => 0,
+      'created' => time(),
+    ])->execute();
+
+    return $challenge;
+  }
+
+  /**
+   * Verify an ECDSA signature of a challenge nonce.
+   *
+   * @param string $device_id
+   *   Device identifier.
+   * @param string $challenge
+   *   Hex-encoded challenge nonce.
+   * @param string $signature_b64
+   *   Base64-encoded ECDSA signature.
+   *
+   * @return bool
+   *   TRUE if signature is valid and device is activated.
+   *
+   * @throws \RuntimeException
+   *   If challenge not found, expired, or already used.
+   */
+  public function verify(string $device_id, string $challenge, string $signature_b64): bool {
+    $row = $this->database->select('bebbo_api_challenges', 'c')
+      ->fields('c')
+      ->condition('c.device_id', $device_id)
+      ->condition('c.challenge', $challenge)
+      ->condition('c.purpose', 'sideloaded_verify')
+      ->execute()
+      ->fetchObject();
+
+    if (!$row) {
+      throw new \RuntimeException('Challenge not found.');
+    }
+    if ((int) $row->used === 1) {
+      throw new \RuntimeException('Challenge already used.');
+    }
+    if ((int) $row->expires < time()) {
+      throw new \RuntimeException('Challenge expired.');
+    }
+
+    $device = $this->database->select('bebbo_api_devices', 'd')
+      ->fields('d', ['public_key'])
+      ->condition('d.device_id', $device_id)
+      ->execute()
+      ->fetchObject();
+
+    if (!$device || empty($device->public_key)) {
+      throw new \RuntimeException('Device public key not found.');
+    }
+
+    $signature = base64_decode($signature_b64, TRUE);
+    if ($signature === FALSE) {
+      throw new \RuntimeException('Invalid base64 signature.');
+    }
+
+    $challenge_bytes = hex2bin($challenge);
+    $result = openssl_verify(
+      $challenge_bytes,
+      $signature,
+      $device->public_key,
+      OPENSSL_ALGO_SHA256
+    );
+
+    // Mark challenge as used regardless of outcome.
+    $this->database->update('bebbo_api_challenges')
+      ->fields(['used' => 1])
+      ->condition('id', $row->id)
+      ->execute();
+
+    if ($result !== 1) {
+      return FALSE;
+    }
+
+    $this->database->update('bebbo_api_devices')
+      ->fields(['status' => 'active', 'updated' => time()])
+      ->condition('device_id', $device_id)
+      ->execute();
+
+    return TRUE;
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/ApiSecuritySubscriberIntegrationTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/ApiSecuritySubscriberIntegrationTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Kernel;
+
+use Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber;
+use Drupal\key\KeyInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Kernel integration tests for ApiSecuritySubscriber.
+ *
+ * Tests all three enforcement modes (disabled, grace_period, enforced),
+ * the dev bypass feature, and protection of both /v2/api/ and
+ * /api/check-update/ route prefixes — using a real JWT issued by JwtService.
+ *
+ * @coversDefaultClass \Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber
+ * @group bebbo_api_security
+ */
+class ApiSecuritySubscriberIntegrationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'bebbo_api_security',
+    'key',
+    'system',
+    'views',
+    'user',
+    'filter',
+  ];
+
+  /**
+   * A valid JWT created in setUp for use in tests.
+   *
+   * @var string
+   */
+  private string $validJwt;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installSchema('bebbo_api_security', [
+      'bebbo_api_devices',
+      'bebbo_api_refresh_tokens',
+      'bebbo_api_challenges',
+      'bebbo_api_security_log',
+    ]);
+    $this->installConfig(['bebbo_api_security']);
+
+    // Generate a throw-away RSA key pair so JwtService can sign tokens.
+    $rsa = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    openssl_pkey_export($rsa, $private_pem);
+
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn($private_pem);
+
+    $key_repo = $this->createMock(KeyRepositoryInterface::class);
+    $key_repo->method('getKey')
+      ->with('bebbo_jwt_signing_key')
+      ->willReturn($key);
+    $this->container->set('key.repository', $key_repo);
+
+    /** @var \Drupal\bebbo_api_security\Service\JwtService $jwtService */
+    $jwtService = $this->container->get('bebbo_api_security.jwt_service');
+    $this->validJwt = $jwtService->createToken(
+      'integration-test-device',
+      'sideloaded',
+      'challenge_response'
+    );
+  }
+
+  /**
+   * Build a RequestEvent for the given path, method, IP, and optional bearer.
+   *
+   * @param string $path
+   *   The request path.
+   * @param string $ip
+   *   The client IP address.
+   * @param string|null $bearerToken
+   *   Optional JWT to attach as Authorization: Bearer.
+   *
+   * @return \Symfony\Component\HttpKernel\Event\RequestEvent
+   *   The constructed event.
+   */
+  private function buildEvent(string $path, string $ip = '127.0.0.1', ?string $bearerToken = NULL): RequestEvent {
+    $server = ['REMOTE_ADDR' => $ip];
+    $request = Request::create($path, 'GET', [], [], [], $server);
+    if ($bearerToken !== NULL) {
+      $request->headers->set('Authorization', "Bearer {$bearerToken}");
+    }
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    return new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+  }
+
+  /**
+   * Get the subscriber under test from the service container.
+   *
+   * @return \Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber
+   *   The event subscriber service.
+   */
+  private function getSubscriber(): ApiSecuritySubscriber {
+    return $this->container->get('bebbo_api_security.request_subscriber');
+  }
+
+  /**
+   * Tests that disabled mode passes all requests without a response.
+   *
+   * @covers ::onRequest
+   */
+  public function testDisabledModeAllowsAll(): void {
+    // Default install config has enforcement_mode = disabled.
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->getSubscriber()->onRequest($event);
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * Tests that enforced mode blocks requests with no token.
+   *
+   * @covers ::onRequest
+   */
+  public function testEnforcedBlocksNoToken(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->getSubscriber()->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertEquals(401, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that enforced mode allows a valid JWT and sets bebbo_device_id.
+   *
+   * @covers ::onRequest
+   */
+  public function testEnforcedAllowsValidJwt(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en', '127.0.0.1', $this->validJwt);
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertEquals(
+      'integration-test-device',
+      $event->getRequest()->attributes->get('bebbo_device_id')
+    );
+  }
+
+  /**
+   * Tests that enforced mode blocks a tampered JWT.
+   *
+   * @covers ::onRequest
+   */
+  public function testEnforcedBlocksTamperedJwt(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->save();
+
+    $tampered = $this->validJwt . 'tampered';
+    $event = $this->buildEvent('/v2/api/articles/en', '127.0.0.1', $tampered);
+    $this->getSubscriber()->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertEquals(401, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that grace_period mode allows requests with no token.
+   *
+   * @covers ::onRequest
+   */
+  public function testGracePeriodAllowsNoToken(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'grace_period')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * Tests that grace_period mode sets bebbo_device_id when a valid JWT is sent.
+   *
+   * @covers ::onRequest
+   */
+  public function testGracePeriodTracksValidJwt(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'grace_period')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en', '127.0.0.1', $this->validJwt);
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertEquals(
+      'integration-test-device',
+      $event->getRequest()->attributes->get('bebbo_device_id')
+    );
+  }
+
+  /**
+   * Tests grace_period passes invalid JWT through without setting device ID.
+   *
+   * @covers ::onRequest
+   */
+  public function testGracePeriodAllowsInvalidJwt(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'grace_period')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en', '127.0.0.1', 'not.a.valid.jwt');
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertNull($event->getRequest()->attributes->get('bebbo_device_id'));
+  }
+
+  /**
+   * Tests that dev bypass allows a matching IP with no token in enforced mode.
+   *
+   * @covers ::onRequest
+   */
+  public function testDevBypassInEnforcedMode(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->set('dev_bypass_enabled', TRUE)
+      ->set('dev_bypass_ips', '10.0.0.1')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en', '10.0.0.1');
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * Tests that dev bypass does not apply to non-matching IPs.
+   *
+   * @covers ::onRequest
+   */
+  public function testDevBypassDoesNotApplyToOtherIps(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->set('dev_bypass_enabled', TRUE)
+      ->set('dev_bypass_ips', '10.0.0.1')
+      ->save();
+
+    $event = $this->buildEvent('/v2/api/articles/en', '192.168.1.1');
+    $this->getSubscriber()->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertEquals(401, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that /api/check-update/ routes are protected in enforced mode.
+   *
+   * @covers ::onRequest
+   */
+  public function testCheckUpdateProtected(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->save();
+
+    $event = $this->buildEvent('/api/check-update/bangladesh');
+    $this->getSubscriber()->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertEquals(401, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that /api/check-update/ routes are allowed with a valid JWT.
+   *
+   * @covers ::onRequest
+   */
+  public function testCheckUpdateAllowedWithJwt(): void {
+    $this->config('bebbo_api_security.settings')
+      ->set('enforcement_mode', 'enforced')
+      ->save();
+
+    $event = $this->buildEvent('/api/check-update/bangladesh', '127.0.0.1', $this->validJwt);
+    $this->getSubscriber()->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertEquals(
+      'integration-test-device',
+      $event->getRequest()->attributes->get('bebbo_device_id')
+    );
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/DeviceRegistryServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/DeviceRegistryServiceTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Kernel;
+
+use Drupal\bebbo_api_security\Service\DeviceRegistryService;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Kernel tests for DeviceRegistryService CRUD and purge operations.
+ *
+ * @coversDefaultClass \Drupal\bebbo_api_security\Service\DeviceRegistryService
+ * @group bebbo_api_security
+ */
+class DeviceRegistryServiceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'bebbo_api_security',
+    'key',
+    'system',
+    'views',
+    'user',
+    'filter',
+  ];
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\bebbo_api_security\Service\DeviceRegistryService
+   */
+  private DeviceRegistryService $registry;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installSchema('bebbo_api_security', [
+      'bebbo_api_devices',
+      'bebbo_api_refresh_tokens',
+      'bebbo_api_challenges',
+      'bebbo_api_security_log',
+    ]);
+    $this->installConfig(['bebbo_api_security']);
+
+    $this->registry = $this->container->get('bebbo_api_security.device_registry');
+  }
+
+  /**
+   * Helper to insert a device with default fields.
+   */
+  private function insertDevice(string $device_id, array $overrides = []): int {
+    return $this->registry->registerDevice($overrides + [
+      'device_id' => $device_id,
+      'platform' => 'android',
+      'auth_method' => 'play_integrity',
+      'status' => 'active',
+      'apple_counter' => 0,
+      'created' => time(),
+      'updated' => time(),
+    ]);
+  }
+
+  /**
+   * Tests registerDevice inserts a record and returns an ID.
+   *
+   * @covers ::registerDevice
+   */
+  public function testRegisterDeviceInsertsRecord(): void {
+    $id = $this->insertDevice('dev-001');
+    $this->assertGreaterThan(0, $id);
+
+    $device = $this->registry->getDevice('dev-001');
+    $this->assertNotNull($device);
+    $this->assertEquals('dev-001', $device->device_id);
+    $this->assertEquals('android', $device->platform);
+    $this->assertEquals('active', $device->status);
+  }
+
+  /**
+   * Tests getDevice returns the device record.
+   *
+   * @covers ::getDevice
+   */
+  public function testGetDeviceReturnsDevice(): void {
+    $this->insertDevice('dev-002', ['platform' => 'ios', 'auth_method' => 'app_attest']);
+    $device = $this->registry->getDevice('dev-002');
+
+    $this->assertNotNull($device);
+    $this->assertEquals('ios', $device->platform);
+    $this->assertEquals('app_attest', $device->auth_method);
+  }
+
+  /**
+   * Tests getDevice returns NULL for non-existent device.
+   *
+   * @covers ::getDevice
+   */
+  public function testGetDeviceReturnsNullForMissing(): void {
+    $this->assertNull($this->registry->getDevice('nonexistent'));
+  }
+
+  /**
+   * Tests getDeviceByAppleKeyId returns the correct device.
+   *
+   * @covers ::getDeviceByAppleKeyId
+   */
+  public function testGetDeviceByAppleKeyId(): void {
+    $this->insertDevice('dev-003', [
+      'platform' => 'ios',
+      'auth_method' => 'app_attest',
+      'apple_key_id' => 'abc123keyid',
+    ]);
+
+    $device = $this->registry->getDeviceByAppleKeyId('abc123keyid');
+    $this->assertNotNull($device);
+    $this->assertEquals('dev-003', $device->device_id);
+  }
+
+  /**
+   * Tests updateDevice modifies specified fields.
+   *
+   * @covers ::updateDevice
+   */
+  public function testUpdateDeviceChangesFields(): void {
+    $this->insertDevice('dev-004');
+    $this->registry->updateDevice('dev-004', [
+      'status' => 'suspended',
+      'updated' => time() + 100,
+    ]);
+
+    $device = $this->registry->getDevice('dev-004');
+    $this->assertEquals('suspended', $device->status);
+  }
+
+  /**
+   * Tests revokeDevice sets status to revoked.
+   *
+   * @covers ::revokeDevice
+   */
+  public function testRevokeDeviceSetsStatus(): void {
+    $this->insertDevice('dev-005');
+    $this->registry->revokeDevice('dev-005');
+
+    $device = $this->registry->getDevice('dev-005');
+    $this->assertEquals('revoked', $device->status);
+  }
+
+  /**
+   * Tests logSecurityEvent inserts audit record.
+   *
+   * @covers ::logSecurityEvent
+   */
+  public function testLogSecurityEventInsertsRecord(): void {
+    $this->registry->logSecurityEvent('register', 'dev-006', '192.168.1.1', ['foo' => 'bar']);
+
+    $log = $this->container->get('database')
+      ->select('bebbo_api_security_log', 'l')
+      ->fields('l')
+      ->condition('l.device_id', 'dev-006')
+      ->execute()
+      ->fetchObject();
+
+    $this->assertNotNull($log);
+    $this->assertEquals('register', $log->event_type);
+    $this->assertEquals('192.168.1.1', $log->ip_address);
+    $this->assertEquals('{"foo":"bar"}', $log->details);
+  }
+
+  /**
+   * Tests purgeExpired removes expired challenges.
+   *
+   * @covers ::purgeExpired
+   */
+  public function testPurgeExpiredCleansUpChallenges(): void {
+    $db = $this->container->get('database');
+    $db->insert('bebbo_api_challenges')->fields([
+      'device_id' => 'dev-007',
+      'challenge' => bin2hex(random_bytes(32)),
+      'purpose' => 'sideloaded_verify',
+      'expires' => time() - 300,
+      'used' => 0,
+      'created' => time() - 400,
+    ])->execute();
+
+    $stats = $this->registry->purgeExpired();
+    $this->assertEquals(1, $stats['challenges']);
+  }
+
+  /**
+   * Tests purgeExpired removes old revoked refresh tokens.
+   *
+   * @covers ::purgeExpired
+   */
+  public function testPurgeExpiredCleansUpRevokedTokens(): void {
+    $db = $this->container->get('database');
+    $db->insert('bebbo_api_refresh_tokens')->fields([
+      'device_id' => 'dev-008',
+      'token_hash' => hash('sha256', 'old-token'),
+      'token_family' => bin2hex(random_bytes(32)),
+      'expires' => time() + 86400,
+      'revoked' => 1,
+      'created' => time() - 700000,
+    ])->execute();
+
+    $stats = $this->registry->purgeExpired();
+    $this->assertEquals(1, $stats['tokens_revoked']);
+  }
+
+  /**
+   * Tests purgeExpired removes expired refresh tokens.
+   *
+   * @covers ::purgeExpired
+   */
+  public function testPurgeExpiredCleansUpExpiredTokens(): void {
+    $db = $this->container->get('database');
+    $db->insert('bebbo_api_refresh_tokens')->fields([
+      'device_id' => 'dev-009',
+      'token_hash' => hash('sha256', 'expired-token'),
+      'token_family' => bin2hex(random_bytes(32)),
+      'expires' => time() - 100,
+      'revoked' => 0,
+      'created' => time() - 200,
+    ])->execute();
+
+    $stats = $this->registry->purgeExpired();
+    $this->assertEquals(1, $stats['tokens_expired']);
+  }
+
+  /**
+   * Tests purgeExpired preserves non-expired active records.
+   *
+   * @covers ::purgeExpired
+   */
+  public function testPurgeExpiredPreservesActiveRecords(): void {
+    $db = $this->container->get('database');
+
+    $db->insert('bebbo_api_challenges')->fields([
+      'device_id' => 'dev-010',
+      'challenge' => bin2hex(random_bytes(32)),
+      'purpose' => 'sideloaded_verify',
+      'expires' => time() + 300,
+      'used' => 0,
+      'created' => time(),
+    ])->execute();
+
+    $db->insert('bebbo_api_refresh_tokens')->fields([
+      'device_id' => 'dev-010',
+      'token_hash' => hash('sha256', 'active-token'),
+      'token_family' => bin2hex(random_bytes(32)),
+      'expires' => time() + 86400,
+      'revoked' => 0,
+      'created' => time(),
+    ])->execute();
+
+    $stats = $this->registry->purgeExpired();
+    $this->assertEquals(0, $stats['challenges']);
+    $this->assertEquals(0, $stats['tokens_revoked']);
+    $this->assertEquals(0, $stats['tokens_expired']);
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/JwtServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/JwtServiceTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Kernel;
+
+use Drupal\bebbo_api_security\Service\JwtService;
+use Drupal\key\KeyInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+/**
+ * Kernel tests for JwtService token lifecycle.
+ *
+ * @coversDefaultClass \Drupal\bebbo_api_security\Service\JwtService
+ * @group bebbo_api_security
+ */
+class JwtServiceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'bebbo_api_security',
+    'key',
+    'system',
+    'views',
+    'user',
+    'filter',
+  ];
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\bebbo_api_security\Service\JwtService
+   */
+  private JwtService $service;
+
+  /**
+   * RSA private key PEM.
+   *
+   * @var string
+   */
+  private string $privateKeyPem;
+
+  /**
+   * RSA public key PEM.
+   *
+   * @var string
+   */
+  private string $publicKeyPem;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installSchema('bebbo_api_security', [
+      'bebbo_api_devices',
+      'bebbo_api_refresh_tokens',
+      'bebbo_api_challenges',
+      'bebbo_api_security_log',
+    ]);
+    $this->installConfig(['bebbo_api_security']);
+
+    $rsa = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    $pem = '';
+    openssl_pkey_export($rsa, $pem);
+    $this->privateKeyPem = $pem;
+    $details = openssl_pkey_get_details($rsa);
+    $this->publicKeyPem = $details['key'];
+
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn($this->privateKeyPem);
+
+    $keyRepo = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepo->method('getKey')
+      ->with('bebbo_jwt_signing_key')
+      ->willReturn($key);
+    $this->container->set('key.repository', $keyRepo);
+
+    $this->service = $this->container->get('bebbo_api_security.jwt_service');
+  }
+
+  /**
+   * Tests that createToken produces a valid RS256 JWT with expected claims.
+   *
+   * @covers ::createToken
+   */
+  public function testCreateTokenReturnsValidJwt(): void {
+    $token = $this->service->createToken('device-001', 'android', 'play_integrity');
+
+    $decoded = JWT::decode($token, new Key($this->publicKeyPem, 'RS256'));
+    $payload = (array) $decoded;
+
+    $this->assertEquals('bebbo-cms', $payload['iss']);
+    $this->assertEquals('device-001', $payload['sub']);
+    $this->assertEquals('android', $payload['platform']);
+    $this->assertEquals('play_integrity', $payload['auth_method']);
+    $this->assertArrayHasKey('jti', $payload);
+    $this->assertEquals(32, strlen($payload['jti']));
+    $this->assertLessThanOrEqual(time() + 3600, $payload['exp']);
+    $this->assertGreaterThanOrEqual(time(), $payload['iat']);
+  }
+
+  /**
+   * Tests that validateToken accepts a freshly created token.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenAcceptsValidToken(): void {
+    $token = $this->service->createToken('device-002', 'ios', 'app_attest');
+    $payload = $this->service->validateToken($token);
+
+    $this->assertNotNull($payload);
+    $this->assertEquals('device-002', $payload['sub']);
+    $this->assertEquals('ios', $payload['platform']);
+    $this->assertEquals('app_attest', $payload['auth_method']);
+  }
+
+  /**
+   * Tests that validateToken returns NULL for an expired token.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenRejectsExpiredToken(): void {
+    $payload = [
+      'iss' => 'bebbo-cms',
+      'sub' => 'device-003',
+      'iat' => time() - 7200,
+      'exp' => time() - 3600,
+      'platform' => 'android',
+      'auth_method' => 'play_integrity',
+      'jti' => bin2hex(random_bytes(16)),
+    ];
+    $expired_token = JWT::encode($payload, $this->privateKeyPem, 'RS256');
+
+    $result = $this->service->validateToken($expired_token);
+    $this->assertNull($result);
+  }
+
+  /**
+   * Tests that validateToken rejects a token with a tampered payload.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenRejectsTamperedPayload(): void {
+    $token = $this->service->createToken('device-004', 'android', 'play_integrity');
+
+    $parts = explode('.', $token);
+    $payload = json_decode(base64_decode($parts[1]), TRUE);
+    $payload['sub'] = 'evil-device';
+    $parts[1] = rtrim(base64_encode(json_encode($payload)), '=');
+    $tampered = implode('.', $parts);
+
+    $result = $this->service->validateToken($tampered);
+    $this->assertNull($result);
+  }
+
+  /**
+   * Tests that validateToken rejects a token signed with a different key.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenRejectsWrongKey(): void {
+    $other_rsa = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    $other_pem = '';
+    openssl_pkey_export($other_rsa, $other_pem);
+
+    $payload = [
+      'iss' => 'bebbo-cms',
+      'sub' => 'device-005',
+      'iat' => time(),
+      'exp' => time() + 3600,
+      'platform' => 'android',
+      'auth_method' => 'play_integrity',
+      'jti' => bin2hex(random_bytes(16)),
+    ];
+    $token = JWT::encode($payload, $other_pem, 'RS256');
+
+    $result = $this->service->validateToken($token);
+    $this->assertNull($result);
+  }
+
+  /**
+   * Tests that validateToken returns NULL for a malformed string.
+   *
+   * @covers ::validateToken
+   */
+  public function testValidateTokenRejectsMalformedString(): void {
+    $result = $this->service->validateToken('not.a.jwt');
+    $this->assertNull($result);
+  }
+
+  /**
+   * Tests that createToken throws when the Key entity is missing.
+   *
+   * @covers ::createToken
+   */
+  public function testCreateTokenThrowsWhenKeyMissing(): void {
+    $keyRepo = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepo->method('getKey')->willReturn(NULL);
+
+    $service = new JwtService(
+      $keyRepo,
+      $this->container->get('database'),
+      $this->container->get('config.factory'),
+      $this->container->get('logger.channel.bebbo_api_security'),
+    );
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('JWT signing key not configured');
+    $service->createToken('device', 'android', 'play_integrity');
+  }
+
+  /**
+   * Tests that createToken throws when the Key entity returns empty value.
+   *
+   * @covers ::createToken
+   */
+  public function testCreateTokenThrowsWhenKeyEmpty(): void {
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn('');
+
+    $keyRepo = $this->createMock(KeyRepositoryInterface::class);
+    $keyRepo->method('getKey')->willReturn($key);
+
+    $service = new JwtService(
+      $keyRepo,
+      $this->container->get('database'),
+      $this->container->get('config.factory'),
+      $this->container->get('logger.channel.bebbo_api_security'),
+    );
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('JWT signing key is empty');
+    $service->createToken('device', 'android', 'play_integrity');
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/SecurityControllerTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/SecurityControllerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Kernel;
+
+use Drupal\bebbo_api_security\Controller\SecurityController;
+use Drupal\key\KeyInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Kernel tests for SecurityController endpoint methods.
+ *
+ * Exercises the sideloaded device flow end-to-end (register -> sign -> verify),
+ * refresh token rotation, and input validation — all through the real service
+ * layer with only the Key repository mocked (to provide a test RSA key).
+ *
+ * @coversDefaultClass \Drupal\bebbo_api_security\Controller\SecurityController
+ * @group bebbo_api_security
+ */
+class SecurityControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'bebbo_api_security',
+    'key',
+    'system',
+    'views',
+    'user',
+    'filter',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installSchema('bebbo_api_security', [
+      'bebbo_api_devices',
+      'bebbo_api_refresh_tokens',
+      'bebbo_api_challenges',
+      'bebbo_api_security_log',
+    ]);
+
+    // Generate an RSA key pair and mock the Key repository so JwtService
+    // can sign/verify tokens without the Key module entity existing.
+    $rsa = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    openssl_pkey_export($rsa, $private_pem);
+
+    $key = $this->createMock(KeyInterface::class);
+    $key->method('getKeyValue')->willReturn($private_pem);
+
+    $key_repo = $this->createMock(KeyRepositoryInterface::class);
+    $key_repo->method('getKey')
+      ->with('bebbo_jwt_signing_key')
+      ->willReturn($key);
+    $this->container->set('key.repository', $key_repo);
+
+    $this->installConfig(['bebbo_api_security']);
+  }
+
+  /**
+   * Instantiate the controller via its DI factory.
+   */
+  private function getController(): SecurityController {
+    return SecurityController::create($this->container);
+  }
+
+  /**
+   * Tests successful sideloaded device registration (step 1).
+   *
+   * @covers ::deviceRegister
+   */
+  public function testDeviceRegisterSuccess(): void {
+    $key = openssl_pkey_new([
+      'curve_name' => 'prime256v1',
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+    ]);
+    $details = openssl_pkey_get_details($key);
+
+    $request = Request::create('/api/security/device/register', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-001',
+      'public_key' => $details['key'],
+    ]));
+
+    $response = $this->getController()->deviceRegister($request);
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $data = json_decode($response->getContent(), TRUE);
+    $this->assertEquals('challenge_issued', $data['status']);
+    $this->assertEquals(64, strlen($data['challenge']));
+    $this->assertEquals(120, $data['expires_in']);
+  }
+
+  /**
+   * Tests that device registration rejects an invalid public key.
+   *
+   * @covers ::deviceRegister
+   */
+  public function testDeviceRegisterRejectsInvalidKey(): void {
+    $request = Request::create('/api/security/device/register', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-002',
+      'public_key' => 'not-a-valid-key',
+    ]));
+
+    $response = $this->getController()->deviceRegister($request);
+    $this->assertEquals(400, $response->getStatusCode());
+  }
+
+  /**
+   * Tests the full sideloaded flow: register -> sign -> verify -> tokens.
+   *
+   * @covers ::deviceRegister
+   * @covers ::deviceVerify
+   */
+  public function testDeviceVerifyFullFlow(): void {
+    $key = openssl_pkey_new([
+      'curve_name' => 'prime256v1',
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+    ]);
+    openssl_pkey_export($key, $private_pem);
+    $details = openssl_pkey_get_details($key);
+
+    // Step 1: Register -- obtain a challenge.
+    $request = Request::create('/api/security/device/register', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-003',
+      'public_key' => $details['key'],
+    ]));
+    $response = $this->getController()->deviceRegister($request);
+    $data = json_decode($response->getContent(), TRUE);
+    $challenge = $data['challenge'];
+
+    // Step 2: Sign the challenge with the EC private key.
+    $challenge_bytes = hex2bin($challenge);
+    openssl_sign($challenge_bytes, $signature, $private_pem, OPENSSL_ALGO_SHA256);
+
+    // Step 3: Verify -- present the signed challenge.
+    $request = Request::create('/api/security/device/verify', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-003',
+      'challenge' => $challenge,
+      'signature' => base64_encode($signature),
+    ]));
+    $response = $this->getController()->deviceVerify($request);
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $data = json_decode($response->getContent(), TRUE);
+    $this->assertEquals('verified', $data['status']);
+    $this->assertNotEmpty($data['access_token']);
+    $this->assertEquals('Bearer', $data['token_type']);
+    $this->assertNotEmpty($data['refresh_token']);
+  }
+
+  /**
+   * Tests refresh token rotation returns new tokens.
+   *
+   * @covers ::refresh
+   */
+  public function testRefreshTokenFlow(): void {
+    // Register + verify a device to obtain tokens.
+    $key = openssl_pkey_new([
+      'curve_name' => 'prime256v1',
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+    ]);
+    openssl_pkey_export($key, $private_pem);
+    $details = openssl_pkey_get_details($key);
+
+    $request = Request::create('/api/security/device/register', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-004',
+      'public_key' => $details['key'],
+    ]));
+    $reg_data = json_decode(
+      $this->getController()->deviceRegister($request)->getContent(),
+      TRUE,
+    );
+
+    $challenge_bytes = hex2bin($reg_data['challenge']);
+    openssl_sign($challenge_bytes, $signature, $private_pem, OPENSSL_ALGO_SHA256);
+
+    $request = Request::create('/api/security/device/verify', 'POST', [], [], [], [], json_encode([
+      'device_id' => 'test-004',
+      'challenge' => $reg_data['challenge'],
+      'signature' => base64_encode($signature),
+    ]));
+    $verify_data = json_decode(
+      $this->getController()->deviceVerify($request)->getContent(),
+      TRUE,
+    );
+
+    // Now refresh using the refresh token.
+    $request = Request::create('/api/security/refresh', 'POST', [], [], [], [], json_encode([
+      'refresh_token' => $verify_data['refresh_token'],
+    ]));
+    $response = $this->getController()->refresh($request);
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $data = json_decode($response->getContent(), TRUE);
+    $this->assertEquals('refreshed', $data['status']);
+    $this->assertNotEmpty($data['access_token']);
+    $this->assertNotEmpty($data['refresh_token']);
+    // Rotation must issue a different refresh token.
+    $this->assertNotEquals($verify_data['refresh_token'], $data['refresh_token']);
+  }
+
+  /**
+   * Tests that the register endpoint rejects invalid JSON.
+   *
+   * @covers ::register
+   */
+  public function testRegisterRejectsInvalidJson(): void {
+    $request = Request::create('/api/security/register', 'POST', [], [], [], [], 'not json');
+    $response = $this->getController()->register($request);
+    $this->assertEquals(400, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that the register endpoint rejects an unsupported platform.
+   *
+   * @covers ::register
+   */
+  public function testRegisterRejectsInvalidPlatform(): void {
+    $request = Request::create('/api/security/register', 'POST', [], [], [], [], json_encode([
+      'platform' => 'windows',
+      'device_id' => 'test-005',
+    ]));
+    $response = $this->getController()->register($request);
+    $this->assertEquals(400, $response->getStatusCode());
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/SideloadedVerificationServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Kernel/SideloadedVerificationServiceTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\bebbo_api_security\Service\SideloadedVerificationService;
+
+/**
+ * @coversDefaultClass \Drupal\bebbo_api_security\Service\SideloadedVerificationService
+ * @group bebbo_api_security
+ */
+class SideloadedVerificationServiceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'bebbo_api_security',
+    'key',
+    'system',
+    'views',
+    'user',
+    'filter',
+  ];
+
+  /**
+   * The sideloaded verification service.
+   *
+   * @var \Drupal\bebbo_api_security\Service\SideloadedVerificationService
+   */
+  private SideloadedVerificationService $service;
+
+  /**
+   * PEM-encoded EC private key for test signing.
+   *
+   * @var string
+   */
+  private string $privateKeyPem;
+
+  /**
+   * PEM-encoded EC public key for test verification.
+   *
+   * @var string
+   */
+  private string $publicKeyPem;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installSchema('bebbo_api_security', [
+      'bebbo_api_devices',
+      'bebbo_api_refresh_tokens',
+      'bebbo_api_challenges',
+      'bebbo_api_security_log',
+    ]);
+
+    $this->service = $this->container->get('bebbo_api_security.sideloaded_verification');
+
+    // Generate EC P-256 key pair for testing.
+    $key = openssl_pkey_new([
+      'curve_name' => 'prime256v1',
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+    ]);
+    $privatePem = '';
+    openssl_pkey_export($key, $privatePem);
+    $this->privateKeyPem = $privatePem;
+    $details = openssl_pkey_get_details($key);
+    $this->publicKeyPem = $details['key'];
+  }
+
+  /**
+   * Tests that registerDevice returns a 64-char hex challenge.
+   *
+   * @covers ::registerDevice
+   */
+  public function testRegisterDeviceReturnsChallenge(): void {
+    $challenge = $this->service->registerDevice('test-device-001', $this->publicKeyPem);
+    $this->assertNotEmpty($challenge);
+    $this->assertEquals(64, strlen($challenge));
+
+    $device = \Drupal::database()->select('bebbo_api_devices', 'd')
+      ->fields('d')
+      ->condition('d.device_id', 'test-device-001')
+      ->execute()
+      ->fetchObject();
+    $this->assertEquals('pending', $device->status);
+    $this->assertEquals('sideloaded', $device->platform);
+  }
+
+  /**
+   * Tests successful ECDSA signature verification activates the device.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyValidSignature(): void {
+    $challenge = $this->service->registerDevice('test-device-002', $this->publicKeyPem);
+
+    $challenge_bytes = hex2bin($challenge);
+    openssl_sign($challenge_bytes, $signature, $this->privateKeyPem, OPENSSL_ALGO_SHA256);
+    $signature_b64 = base64_encode($signature);
+
+    $result = $this->service->verify('test-device-002', $challenge, $signature_b64);
+    $this->assertTrue($result);
+
+    $device = \Drupal::database()->select('bebbo_api_devices', 'd')
+      ->fields('d')
+      ->condition('d.device_id', 'test-device-002')
+      ->execute()
+      ->fetchObject();
+    $this->assertEquals('active', $device->status);
+  }
+
+  /**
+   * Tests that an invalid signature returns FALSE.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyInvalidSignature(): void {
+    $challenge = $this->service->registerDevice('test-device-003', $this->publicKeyPem);
+
+    $result = $this->service->verify('test-device-003', $challenge, base64_encode('invalid'));
+    $this->assertFalse($result);
+  }
+
+  /**
+   * Tests that an expired challenge throws RuntimeException.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyExpiredChallenge(): void {
+    $challenge = $this->service->registerDevice('test-device-004', $this->publicKeyPem);
+
+    \Drupal::database()->update('bebbo_api_challenges')
+      ->fields(['expires' => time() - 1])
+      ->condition('challenge', $challenge)
+      ->execute();
+
+    $challenge_bytes = hex2bin($challenge);
+    openssl_sign($challenge_bytes, $signature, $this->privateKeyPem, OPENSSL_ALGO_SHA256);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Challenge expired');
+    $this->service->verify('test-device-004', $challenge, base64_encode($signature));
+  }
+
+  /**
+   * Tests that reusing a challenge throws RuntimeException.
+   *
+   * @covers ::verify
+   */
+  public function testVerifyChallengeReuse(): void {
+    $challenge = $this->service->registerDevice('test-device-005', $this->publicKeyPem);
+
+    $challenge_bytes = hex2bin($challenge);
+    openssl_sign($challenge_bytes, $signature, $this->privateKeyPem, OPENSSL_ALGO_SHA256);
+    $signature_b64 = base64_encode($signature);
+
+    $this->service->verify('test-device-005', $challenge, $signature_b64);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Challenge already used');
+    $this->service->verify('test-device-005', $challenge, $signature_b64);
+  }
+
+  /**
+   * Tests that a non-EC key is rejected during registration.
+   *
+   * @covers ::registerDevice
+   */
+  public function testRejectNonEcKey(): void {
+    $rsa = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    $details = openssl_pkey_get_details($rsa);
+    $rsa_pub = $details['key'];
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('EC P-256');
+    $this->service->registerDevice('test-device-rsa', $rsa_pub);
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Unit/ApiSecuritySubscriberTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Unit/ApiSecuritySubscriberTest.php
@@ -1,0 +1,381 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Unit;
+
+use Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber;
+use Drupal\bebbo_api_security\Service\JwtService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @coversDefaultClass \Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber
+ * @group bebbo_api_security
+ */
+class ApiSecuritySubscriberTest extends TestCase {
+
+  /**
+   * The subscriber under test.
+   *
+   * @var \Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber
+   */
+  private ApiSecuritySubscriber $subscriber;
+
+  /**
+   * Mock JWT service.
+   *
+   * @var \Drupal\bebbo_api_security\Service\JwtService|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $jwtService;
+
+  /**
+   * Mock immutable config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $config;
+
+  /**
+   * Mock logger.
+   *
+   * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->jwtService = $this->createMock(JwtService::class);
+    $this->config = $this->createMock(ImmutableConfig::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')
+      ->with('bebbo_api_security.settings')
+      ->willReturn($this->config);
+
+    $this->subscriber = new ApiSecuritySubscriber(
+      $this->jwtService,
+      $configFactory,
+      $this->logger,
+    );
+  }
+
+  /**
+   * Build a request event for the given path.
+   *
+   * Optionally sets an Authorization header and server variables.
+   */
+  private function buildEvent(string $path, string $authorization = '', array $server = []): RequestEvent {
+    $request = Request::create($path, 'GET', [], [], [], $server);
+    if ($authorization !== '') {
+      $request->headers->set('Authorization', $authorization);
+    }
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    return new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+  }
+
+  /**
+   * Call the private isProtectedPath() via reflection.
+   */
+  private function callIsProtectedPath(string $path): bool {
+    $method = new \ReflectionMethod($this->subscriber, 'isProtectedPath');
+    $method->setAccessible(TRUE);
+    return $method->invoke($this->subscriber, $path);
+  }
+
+  /**
+   * Data provider: paths that must be matched as protected.
+   *
+   * @return array<string, array{string}>
+   *   Keyed by path string.
+   */
+  public static function protectedPathsProvider(): array {
+    return [
+      '/v2/api/articles/en' => ['/v2/api/articles/en'],
+      '/v2/api/milestones/en/123' => ['/v2/api/milestones/en/123'],
+      '/v2/api/activities/en/1/2' => ['/v2/api/activities/en/1/2'],
+      '/v2/api/vaccinations/en' => ['/v2/api/vaccinations/en'],
+      '/v2/api/faqs/en/42' => ['/v2/api/faqs/en/42'],
+      '/v2/api/course/en' => ['/v2/api/course/en'],
+      '/v2/api/quiz/en' => ['/v2/api/quiz/en'],
+      '/v2/api/guide/en' => ['/v2/api/guide/en'],
+      '/v2/api/taxonomies/en/tags' => ['/v2/api/taxonomies/en/tags'],
+      '/v2/api/vocabularies/en' => ['/v2/api/vocabularies/en'],
+      '/v2/api/country-groups/en' => ['/v2/api/country-groups/en'],
+      '/v2/api/weekly-overview/en' => ['/v2/api/weekly-overview/en'],
+      '/v2/api/child-development-data/en' => ['/v2/api/child-development-data/en'],
+      '/v2/api/child-growth-data/en' => ['/v2/api/child-growth-data/en'],
+      '/v2/api/health-checkup-data/en' => ['/v2/api/health-checkup-data/en'],
+      '/v2/api/standard_deviation/en' => ['/v2/api/standard_deviation/en'],
+      '/v2/api/daily-homescreen-messages/en' => ['/v2/api/daily-homescreen-messages/en'],
+      '/v2/api/basic-pages/en' => ['/v2/api/basic-pages/en'],
+      '/v2/api/surveys/en' => ['/v2/api/surveys/en'],
+      '/v2/api/video-articles/en/1' => ['/v2/api/video-articles/en/1'],
+      '/v2/api/archive/en/1' => ['/v2/api/archive/en/1'],
+      '/api/check-update/bangladesh' => ['/api/check-update/bangladesh'],
+    ];
+  }
+
+  /**
+   * Data provider: paths that must NOT be matched as protected.
+   *
+   * @return array<string, array{string}>
+   *   Keyed by path string.
+   */
+  public static function unprotectedPathsProvider(): array {
+    return [
+      '/api/security/register' => ['/api/security/register'],
+      '/api/security/device/register' => ['/api/security/device/register'],
+      '/api/security/device/verify' => ['/api/security/device/verify'],
+      '/api/security/refresh' => ['/api/security/refresh'],
+      '/api/security/revoke' => ['/api/security/revoke'],
+      '/admin/config/parent-buddy/api-security' => ['/admin/config/parent-buddy/api-security'],
+      '/' => ['/'],
+      '/node/1' => ['/node/1'],
+      '/api/articles/en' => ['/api/articles/en'],
+    ];
+  }
+
+  /**
+   * @covers ::onRequest
+   * @dataProvider protectedPathsProvider
+   */
+  public function testProtectedPathsAreMatched(string $path): void {
+    $this->assertTrue($this->callIsProtectedPath($path), "$path should be protected");
+  }
+
+  /**
+   * @covers ::onRequest
+   * @dataProvider unprotectedPathsProvider
+   */
+  public function testUnprotectedPathsAreSkipped(string $path): void {
+    $this->assertFalse($this->callIsProtectedPath($path), "$path should not be protected");
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testDisabledModeAllowsEverything(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'disabled'],
+      ['dev_bypass_enabled', FALSE],
+    ]);
+
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testGracePeriodAllowsWithoutToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'grace_period'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testGracePeriodSetsDeviceIdWithValidToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'grace_period'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+    $this->jwtService->method('validateToken')
+      ->willReturn(['sub' => 'device-123']);
+
+    $event = $this->buildEvent('/v2/api/articles/en', 'Bearer valid-jwt');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertSame(
+      'device-123',
+      $event->getRequest()->attributes->get('bebbo_device_id')
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testGracePeriodLogsInvalidToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'grace_period'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+    $this->jwtService->method('validateToken')->willReturn(NULL);
+    $this->logger->expects($this->once())->method('warning');
+
+    $event = $this->buildEvent('/v2/api/articles/en', 'Bearer bad-jwt');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testEnforcedModeBlocksWithoutToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'enforced'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+
+    $event = $this->buildEvent('/v2/api/articles/en');
+    $this->subscriber->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertSame(401, $response->getStatusCode());
+
+    $data = json_decode($response->getContent(), TRUE);
+    $this->assertSame('missing_token', $data['error']);
+    $this->assertSame('Bearer realm="Bebbo API"', $response->headers->get('WWW-Authenticate'));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testEnforcedModeBlocksInvalidToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'enforced'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+    $this->jwtService->method('validateToken')->willReturn(NULL);
+
+    $event = $this->buildEvent('/v2/api/articles/en', 'Bearer bad-jwt');
+    $this->subscriber->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertSame(401, $response->getStatusCode());
+
+    $data = json_decode($response->getContent(), TRUE);
+    $this->assertSame('invalid_token', $data['error']);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testEnforcedModeAllowsValidToken(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'enforced'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', ''],
+    ]);
+    $this->jwtService->method('validateToken')
+      ->willReturn(['sub' => 'device-abc']);
+
+    $event = $this->buildEvent('/v2/api/articles/en', 'Bearer good-jwt');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+    $this->assertSame(
+      'device-abc',
+      $event->getRequest()->attributes->get('bebbo_device_id')
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testDevBypassSkipsValidation(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'enforced'],
+      ['dev_bypass_enabled', TRUE],
+      ['dev_bypass_ips', "127.0.0.1\n"],
+    ]);
+
+    $event = $this->buildEvent(
+      '/v2/api/articles/en',
+      '',
+      ['REMOTE_ADDR' => '127.0.0.1']
+    );
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testDevBypassDisabledDoesNotSkip(): void {
+    $this->config->method('get')->willReturnMap([
+      ['enforcement_mode', 'enforced'],
+      ['dev_bypass_enabled', FALSE],
+      ['dev_bypass_ips', "127.0.0.1\n"],
+    ]);
+
+    $event = $this->buildEvent(
+      '/v2/api/articles/en',
+      '',
+      ['REMOTE_ADDR' => '127.0.0.1']
+    );
+    $this->subscriber->onRequest($event);
+
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertSame(401, $response->getStatusCode());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testNonProtectedPathIgnoredInEnforcedMode(): void {
+    // Config should never be consulted for unprotected paths.
+    $this->config->expects($this->never())->method('get');
+
+    $event = $this->buildEvent('/node/1');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testSecurityEndpointExcludedInEnforcedMode(): void {
+    // Config should never be consulted for excluded security paths.
+    $this->config->expects($this->never())->method('get');
+
+    $event = $this->buildEvent('/api/security/register');
+    $this->subscriber->onRequest($event);
+
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * @covers ::getSubscribedEvents
+   */
+  public function testSubscriberPriority(): void {
+    $events = ApiSecuritySubscriber::getSubscribedEvents();
+
+    $this->assertArrayHasKey(KernelEvents::REQUEST, $events);
+    $this->assertSame(['onRequest', 300], $events[KernelEvents::REQUEST]);
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Unit/AppleAppAttestServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Unit/AppleAppAttestServiceTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Unit;
+
+use CBOR\ByteStringObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Drupal\bebbo_api_security\Service\AppleAppAttestService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Database\Connection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for AppleAppAttestService attestation and assertion logic.
+ *
+ * @coversDefaultClass \Drupal\bebbo_api_security\Service\AppleAppAttestService
+ * @group bebbo_api_security
+ */
+class AppleAppAttestServiceTest extends TestCase {
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\bebbo_api_security\Service\AppleAppAttestService
+   */
+  private AppleAppAttestService $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $database = $this->createMock(Connection::class);
+    $logger = $this->createMock(LoggerInterface::class);
+
+    $mockConfig = $this->createMock(ImmutableConfig::class);
+    $mockConfig->method('get')->willReturnMap([
+      ['apple_team_id', 'TESTTEAMID'],
+      ['apple_bundle_id', 'com.example.testapp'],
+      ['apple_production_mode', FALSE],
+    ]);
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')
+      ->with('bebbo_api_security.settings')
+      ->willReturn($mockConfig);
+
+    $this->service = new AppleAppAttestService(
+      $database,
+      $configFactory,
+      $logger,
+    );
+  }
+
+  /**
+   * Tests parseAuthData correctly extracts fields from binary data.
+   *
+   * @covers ::parseAuthData
+   */
+  public function testParseAuthDataExtractsFields(): void {
+    $rp_id_hash = hash('sha256', 'TESTTEAMID.com.example.testapp', TRUE);
+    $flags = chr(0x41);
+    $counter = pack('N', 0);
+    $aaguid = "appattestdevelop";
+    $cred_id = random_bytes(32);
+    $cred_id_len = pack('n', strlen($cred_id));
+    $cose_key = random_bytes(77);
+
+    $auth_data = $rp_id_hash . $flags . $counter . $aaguid
+      . $cred_id_len . $cred_id . $cose_key;
+
+    $method = new \ReflectionMethod($this->service, 'parseAuthData');
+    $method->setAccessible(TRUE);
+    $result = $method->invoke($this->service, $auth_data);
+
+    $this->assertEquals($rp_id_hash, $result['rp_id_hash']);
+    $this->assertEquals(0x41, $result['flags']);
+    $this->assertEquals(0, $result['counter']);
+    $this->assertEquals($aaguid, $result['aaguid']);
+    $this->assertEquals($cred_id, $result['credential_id']);
+    $this->assertEquals($cose_key, $result['cose_key_bytes']);
+  }
+
+  /**
+   * Tests parseAuthData with non-zero counter value.
+   *
+   * @covers ::parseAuthData
+   */
+  public function testParseAuthDataWithNonZeroCounter(): void {
+    $auth_data = str_repeat("\x00", 32)
+      . chr(0x01)
+      . pack('N', 42)
+      . str_repeat("\x00", 16)
+      . pack('n', 4)
+      . "test"
+      . "cosedata";
+
+    $method = new \ReflectionMethod($this->service, 'parseAuthData');
+    $method->setAccessible(TRUE);
+    $result = $method->invoke($this->service, $auth_data);
+
+    $this->assertEquals(42, $result['counter']);
+    $this->assertEquals("test", $result['credential_id']);
+  }
+
+  /**
+   * Tests coseKeyToPem produces a valid PEM for EC P-256.
+   *
+   * @covers ::coseKeyToPem
+   */
+  public function testCoseKeyToPemReturnsValidPem(): void {
+    $ec = openssl_pkey_new([
+      'curve_name' => 'prime256v1',
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+    ]);
+    $details = openssl_pkey_get_details($ec);
+    $x = str_pad($details['ec']['x'], 32, "\x00", STR_PAD_LEFT);
+    $y = str_pad($details['ec']['y'], 32, "\x00", STR_PAD_LEFT);
+
+    $cose_map = MapObject::create()
+      ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
+      ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
+      ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
+      ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($x))
+      ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($y));
+
+    $cose_bytes = (string) $cose_map;
+
+    $method = new \ReflectionMethod($this->service, 'coseKeyToPem');
+    $method->setAccessible(TRUE);
+    $pem = $method->invoke($this->service, $cose_bytes);
+
+    $this->assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $pem);
+    $this->assertStringContainsString('-----END PUBLIC KEY-----', $pem);
+    $key = openssl_pkey_get_public($pem);
+    $this->assertNotFalse($key);
+  }
+
+  /**
+   * Tests verifyAttestation rejects invalid base64 input.
+   *
+   * @covers ::verifyAttestation
+   */
+  public function testVerifyAttestationRejectsInvalidBase64(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Invalid base64');
+    $this->service->verifyAttestation('!!!not-base64!!!', 'key', 'hash', 'dev');
+  }
+
+  /**
+   * Tests verifyAttestation rejects invalid CBOR data.
+   *
+   * @covers ::verifyAttestation
+   */
+  public function testVerifyAttestationRejectsBadCbor(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('CBOR decode failed');
+    $this->service->verifyAttestation(
+      base64_encode("\xFF\xFE\xFD"),
+      'key',
+      'hash',
+      'dev',
+    );
+  }
+
+  /**
+   * Tests verifyAttestation rejects wrong attestation format.
+   *
+   * @covers ::verifyAttestation
+   */
+  public function testVerifyAttestationRejectsWrongFormat(): void {
+    $cbor = MapObject::create()
+      ->add(TextStringObject::create('fmt'), TextStringObject::create('packed'))
+      ->add(TextStringObject::create('authData'), ByteStringObject::create(str_repeat("\x00", 64)))
+      ->add(TextStringObject::create('attStmt'), MapObject::create());
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Unexpected attestation format');
+    $this->service->verifyAttestation(
+      base64_encode((string) $cbor),
+      'key',
+      'hash',
+      'dev',
+    );
+  }
+
+  /**
+   * Tests verifyAttestation rejects authData that is too short.
+   *
+   * @covers ::verifyAttestation
+   */
+  public function testVerifyAttestationRejectsShortAuthData(): void {
+    $cbor = MapObject::create()
+      ->add(TextStringObject::create('fmt'), TextStringObject::create('apple-appattest'))
+      ->add(TextStringObject::create('authData'), ByteStringObject::create(str_repeat("\x00", 20)))
+      ->add(TextStringObject::create('attStmt'), MapObject::create());
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('authData too short');
+    $this->service->verifyAttestation(
+      base64_encode((string) $cbor),
+      'key',
+      'hash',
+      'dev',
+    );
+  }
+
+  /**
+   * Tests verifyAssertion rejects invalid base64.
+   *
+   * @covers ::verifyAssertion
+   */
+  public function testVerifyAssertionRejectsInvalidBase64(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Invalid base64 assertion');
+    $this->service->verifyAssertion('!!!bad!!!', 'hash', 'key', 'pubkey', 0);
+  }
+
+  /**
+   * Tests verifyAssertion rejects authenticatorData that is too short.
+   *
+   * @covers ::verifyAssertion
+   */
+  public function testVerifyAssertionRejectsShortAuthData(): void {
+    $cbor = MapObject::create()
+      ->add(TextStringObject::create('signature'), ByteStringObject::create('sig'))
+      ->add(TextStringObject::create('authenticatorData'), ByteStringObject::create(str_repeat("\x00", 10)));
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('authenticatorData too short');
+    $this->service->verifyAssertion(
+      base64_encode((string) $cbor),
+      'aabb',
+      'key',
+      'pubkey',
+      0,
+    );
+  }
+
+  /**
+   * Tests derToPem wraps DER bytes in correct PEM headers.
+   *
+   * @covers ::derToPem
+   */
+  public function testDerToPemFormatsCorrectly(): void {
+    $method = new \ReflectionMethod($this->service, 'derToPem');
+    $method->setAccessible(TRUE);
+
+    $der = random_bytes(64);
+    $pem = $method->invoke($this->service, $der, 'CERTIFICATE');
+
+    $this->assertStringStartsWith("-----BEGIN CERTIFICATE-----\n", $pem);
+    $this->assertStringEndsWith("-----END CERTIFICATE-----\n", $pem);
+    $this->assertEquals($der, base64_decode(
+      str_replace(
+        ["-----BEGIN CERTIFICATE-----\n", "\n-----END CERTIFICATE-----\n", "\n"],
+        ['', '', ''],
+        $pem,
+      ),
+    ));
+  }
+
+}

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Unit/GooglePlayIntegrityServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Unit/GooglePlayIntegrityServiceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\bebbo_api_security\Unit;
+
+use Drupal\bebbo_api_security\Service\GooglePlayIntegrityService;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\key\KeyRepositoryInterface;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\bebbo_api_security\Service\GooglePlayIntegrityService
+ * @group bebbo_api_security
+ */
+class GooglePlayIntegrityServiceTest extends TestCase {
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\bebbo_api_security\Service\GooglePlayIntegrityService
+   */
+  private GooglePlayIntegrityService $service;
+
+  /**
+   * Mock config object for bebbo_api_security.settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $mockConfig;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $httpClient = $this->createMock(ClientInterface::class);
+    $keyRepository = $this->createMock(KeyRepositoryInterface::class);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $logger = $this->createMock(LoggerInterface::class);
+
+    $this->mockConfig = $this->createMock(ImmutableConfig::class);
+    $this->mockConfig->method('get')->willReturnMap([
+      ['google_package_name', 'org.unicef.bebbo'],
+      ['google_project_number', '123456789'],
+      ['google_verdict_freshness_seconds', 600],
+    ]);
+    $configFactory->method('get')
+      ->with('bebbo_api_security.settings')
+      ->willReturn($this->mockConfig);
+
+    $this->service = new GooglePlayIntegrityService(
+      $httpClient,
+      $keyRepository,
+      $configFactory,
+      $logger,
+    );
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsAcceptsValidPayload(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+          'requestHash' => $request_hash,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    // Should not throw.
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+    $this->assertTrue(TRUE);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsWrongPackage(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'com.evil.app',
+          'timestampMillis' => (string) (time() * 1000),
+          'requestHash' => $request_hash,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Package name mismatch');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsStaleToken(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) ((time() - 700) * 1000),
+          'requestHash' => $request_hash,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('too old');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsRootedDevice(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+          'requestHash' => $request_hash,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => [],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('does not meet integrity requirements');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsUnrecognizedApp(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+          'requestHash' => $request_hash,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'UNEVALUATED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('not recognized by Play Store');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsWrongRequestHash(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+          'requestHash' => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('requestHash mismatch');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsMissingRequestHash(): void {
+    $device_id = 'test-device';
+    $request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+
+    $payload = [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'PLAY_RECOGNIZED',
+        ],
+      ],
+    ];
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('requestHash mismatch');
+    $method->invoke($this->service, $payload, $device_id, $request_hash);
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds a new custom Drupal module (`bebbo_api_security`) that protects V2 API endpoints with device attestation and JWT-based authentication. Mobile clients prove device integrity before receiving access tokens. Three platform-specific attestation flows are supported, plus a gradual rollout mechanism that lets existing unauthenticated clients continue working during migration.

---

## What This Module Does

### Device Registration & Attestation (3 platforms)

- Android — Google Play Integrity API:
  - verifies device/app integrity via Google's attestation service
  - checks verdict fields (`MEETS_DEVICE_INTEGRITY`, `MEETS_BASIC_INTEGRITY`)

- iOS — Apple App Attest:
  - validates CBOR-encoded attestation objects
  - verifies certificate chains against Apple's root CA
  - extracts EC public keys from COSE credential data

- Sideloaded/Dev — ECDSA challenge-response:
  - device registers an EC P-256 public key
  - signs a server-issued challenge
  - server verifies the signature

---

## JWT Token Lifecycle

- RS256 JWT access tokens (configurable expiry, default 1 hour)
- Refresh token rotation with replay detection (token family tracking)
- Automatic revocation of entire token family on reuse (prevents token theft)

---

## Request Middleware (`ApiSecuritySubscriber`)

- Intercepts all `/v2/api/*` and `/api/check-update/*` requests
- Three enforcement modes:
  - `disabled`
  - `grace_period`
  - `enforced`
- Grace period logs unauthenticated requests without blocking (migration visibility)
- Dev bypass:
  - configurable IP allowlist for development/testing
- Sets `bebbo_device_id` request attribute for downstream use

---

## Admin Interface

- Settings form:
  - enforcement mode
  - platform toggles
  - token lifetimes
  - rate limits
  - dev bypass IPs

- 4 admin Views:
  - Registered Devices
  - Refresh Tokens
  - Challenges
  - Security Audit Log

- All views accessible under:
  - `Admin → Configuration → API Security` tabs

---

## Architecture

```text
┌─────────────────────────────────────────────────────┐
│  Mobile Client                                       │
│  (Android / iOS / Sideloaded)                        │
└──────────┬──────────────────────────────────────────┘
           │
           ▼
┌──────────────────────────────────────────────────────┐
│  SecurityController (5 endpoints)                     │
│  POST /api/security/register                          │
│  POST /api/security/device/register  (sideloaded)     │
│  POST /api/security/device/verify    (sideloaded)     │
│  POST /api/security/refresh                           │
│  POST /api/security/status                            │
└──────────┬──────────────────────────────────────────┘
           │
     ┌─────┴──────────────────┐
     ▼                        ▼
┌────────────────┐  ┌───────────────────────────────┐
│  JwtService    │  │  Platform Attestation Services │
│  (RS256 JWT)   │  │  • GooglePlayIntegrityService  │
│  • create      │  │  • AppleAppAttestService       │
│  • validate    │  │  • SideloadedVerificationSvc   │
│  • refresh     │  └───────────────────────────────┘
└────────────────┘
           │
           ▼
┌──────────────────────────────────────────────────────┐
│  DeviceRegistryService                                │
│  4 tables: devices, refresh_tokens, challenges, log   │
└──────────────────────────────────────────────────────┘
           │
           ▼
┌──────────────────────────────────────────────────────┐
│  ApiSecuritySubscriber (event subscriber)              │
│  Intercepts /v2/api/* and /api/check-update/*         │
│  Validates JWT → sets bebbo_device_id on request      │
│  Enforcement: disabled | grace_period | enforced      │
└──────────────────────────────────────────────────────┘
```

---

## Database Schema

| Table | Purpose |
|---|---|
| `bebbo_api_devices` | Registered devices: device_id, platform, status, public keys, attestation metadata |
| `bebbo_api_refresh_tokens` | Refresh tokens with family-based rotation and revocation tracking |
| `bebbo_api_challenges` | Time-limited challenges for sideloaded ECDSA verification |
| `bebbo_api_security_log` | Audit log: registration, verification, token refresh, failures |

---

## Test Coverage

100 tests, 184 assertions across 8 test classes:

| Test Class | Type | Tests | Covers |
|---|---|---|---|
| `JwtServiceTest` | Kernel | 8 | Token create/validate round-trip, expiry, tampering, wrong key, missing key |
| `AppleAppAttestServiceTest` | Unit | 10 | AuthData parsing, COSE-to-PEM, attestation/assertion error paths |
| `GooglePlayIntegrityServiceTest` | Unit | 7 | Verdict checking, error handling, config-driven behavior |
| `DeviceRegistryServiceTest` | Kernel | 11 | Device CRUD, revoke, audit log, purge expired challenges/tokens |
| `SideloadedVerificationServiceTest` | Kernel | 6 | ECDSA registration, valid/invalid signatures, expiry, replay, key rejection |
| `SecurityControllerTest` | Kernel | 7 | Full sideloaded flow, refresh rotation, input validation |
| `ApiSecuritySubscriberTest` | Unit | 14 | All 3 modes, dev bypass, route matching, header parsing |
| `ApiSecuritySubscriberIntegrationTest` | Kernel | 8 | Real JWT through middleware, grace period tracking, check-update routes |

No real Apple/Google credentials in code — tests use synthetic data and fake identifiers.

---

## Configuration

- Admin settings form at:
  - `/admin/config/services/api-security`

- `bebbo_api_security.settings` added to config ignore:
  - admin form values (secrets, API keys, enforcement mode) never export to git

- RSA signing key managed via Key module:
  - `bebbo_jwt_signing_key` entity

- Google service account key via Key module:
  - `bebbo_google_sa_key` entity

- Apple configuration (Team ID, Bundle ID) set via admin form only

---

## Files Changed

- 32 new files in `docroot/modules/custom/bebbo_api_security/` (`7,239` lines)
- 1 modified file:
  - `config/sync/config_ignore.settings.yml`
  - added security settings to ignore list
