### PR TITLE
refactor: move hardcoded values to config form in bebbo_api_security

### DIFF
--- a/config/sync/views.view.bebbo_api_challenges.yml
+++ b/config/sync/views.view.bebbo_api_challenges.yml
@@ -366,8 +366,8 @@ display:
           label: Created
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ created|date("m/d/Y H:i A") }}'
             make_link: false
             path: ''
             absolute: false
@@ -661,6 +661,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }
@@ -685,6 +686,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.bebbo_api_devices.yml
+++ b/config/sync/views.view.bebbo_api_devices.yml
@@ -358,8 +358,8 @@ display:
           label: Updated
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ updated|date("m/d/Y H:i A") }}'
             make_link: false
             path: ''
             absolute: false
@@ -694,6 +694,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }
@@ -718,6 +719,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.bebbo_api_refresh_tokens.yml
+++ b/config/sync/views.view.bebbo_api_refresh_tokens.yml
@@ -366,8 +366,8 @@ display:
           label: Created
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ created|date("m/d/Y H:i A") }}'
             make_link: false
             path: ''
             absolute: false
@@ -620,6 +620,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }
@@ -644,6 +645,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.bebbo_api_security_log.yml
+++ b/config/sync/views.view.bebbo_api_security_log.yml
@@ -299,8 +299,8 @@ display:
           label: Created
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ created|date("m/d/Y H:i A") }}'
             make_link: false
             path: ''
             absolute: false
@@ -627,6 +627,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }
@@ -651,6 +652,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags: {  }

--- a/docroot/modules/custom/bebbo_api_security/bebbo_api_security.services.yml
+++ b/docroot/modules/custom/bebbo_api_security/bebbo_api_security.services.yml
@@ -8,6 +8,7 @@ services:
     arguments:
       - '@database'
       - '@logger.channel.bebbo_api_security'
+      - '@config.factory'
 
   bebbo_api_security.jwt_service:
     class: Drupal\bebbo_api_security\Service\JwtService
@@ -37,6 +38,7 @@ services:
     arguments:
       - '@database'
       - '@logger.channel.bebbo_api_security'
+      - '@config.factory'
 
   bebbo_api_security.request_subscriber:
     class: Drupal\bebbo_api_security\EventSubscriber\ApiSecuritySubscriber

--- a/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
@@ -12,3 +12,13 @@ refresh_expiry_seconds: 2592000
 refresh_rotation_enabled: true
 register_rate_limit: 10
 refresh_rate_limit: 30
+apple_root_ca_pem: ''
+debug_logging: false
+challenge_expiry_seconds: 120
+google_api_timeout: 10
+device_register_ip_rate_limit: 5
+verify_rate_limit: 10
+revoked_token_retention_days: 7
+security_log_max_entries: 10000
+protected_api_patterns: "/v2/api/\n/api/check-update/"
+excluded_api_patterns: "/api/security/"

--- a/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
@@ -44,3 +44,33 @@ bebbo_api_security.settings:
     refresh_rate_limit:
       type: integer
       label: 'Refresh rate limit per device per hour'
+    apple_root_ca_pem:
+      type: text
+      label: 'Apple App Attestation Root CA PEM certificate'
+    debug_logging:
+      type: boolean
+      label: 'Enable debug logging for API security'
+    challenge_expiry_seconds:
+      type: integer
+      label: 'Challenge expiry in seconds'
+    google_api_timeout:
+      type: integer
+      label: 'Google API HTTP timeout in seconds'
+    device_register_ip_rate_limit:
+      type: integer
+      label: 'Device registration rate limit per IP per hour'
+    verify_rate_limit:
+      type: integer
+      label: 'Verification rate limit per device per hour'
+    revoked_token_retention_days:
+      type: integer
+      label: 'Revoked token retention in days'
+    security_log_max_entries:
+      type: integer
+      label: 'Maximum security log entries to keep'
+    protected_api_patterns:
+      type: string
+      label: 'Protected API route patterns (newline-separated)'
+    excluded_api_patterns:
+      type: string
+      label: 'Excluded API route patterns (newline-separated)'

--- a/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
@@ -77,7 +77,9 @@ class SecurityController extends ControllerBase {
     $device_id = $body['device_id'];
     $ip = $request->getClientIp() ?? '0.0.0.0';
 
-    $rate_error = $this->rateLimit($device_id, 'bebbo_register', 10, 3600);
+    $config = $this->config('bebbo_api_security.settings');
+    $limit = (int) $config->get('register_rate_limit') ?: 10;
+    $rate_error = $this->rateLimit($device_id, 'bebbo_register', $limit, 3600);
     if ($rate_error) {
       return $rate_error;
     }
@@ -168,7 +170,9 @@ class SecurityController extends ControllerBase {
     }
 
     $ip = $request->getClientIp() ?? '0.0.0.0';
-    $rate_error = $this->rateLimit($ip, 'bebbo_device_register', 5, 3600);
+    $config = $this->config('bebbo_api_security.settings');
+    $limit = (int) $config->get('device_register_ip_rate_limit') ?: 5;
+    $rate_error = $this->rateLimit($ip, 'bebbo_device_register', $limit, 3600);
     if ($rate_error) {
       return $rate_error;
     }
@@ -186,10 +190,11 @@ class SecurityController extends ControllerBase {
       ], 400);
     }
 
+    $challenge_expiry = (int) $config->get('challenge_expiry_seconds') ?: 120;
     return new JsonResponse([
       'status' => 'challenge_issued',
       'challenge' => $challenge,
-      'expires_in' => 120,
+      'expires_in' => $challenge_expiry,
     ]);
   }
 
@@ -209,7 +214,9 @@ class SecurityController extends ControllerBase {
     $device_id = $body['device_id'];
     $ip = $request->getClientIp() ?? '0.0.0.0';
 
-    $rate_error = $this->rateLimit($device_id, 'bebbo_device_verify', 10, 3600);
+    $config = $this->config('bebbo_api_security.settings');
+    $limit = (int) $config->get('verify_rate_limit') ?: 10;
+    $rate_error = $this->rateLimit($device_id, 'bebbo_device_verify', $limit, 3600);
     if ($rate_error) {
       return $rate_error;
     }

--- a/docroot/modules/custom/bebbo_api_security/src/EventSubscriber/ApiSecuritySubscriber.php
+++ b/docroot/modules/custom/bebbo_api_security/src/EventSubscriber/ApiSecuritySubscriber.php
@@ -18,15 +18,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class ApiSecuritySubscriber implements EventSubscriberInterface {
 
-  private const PROTECTED_PATTERNS = [
-    '#^/v2/api/#',
-    '#^/api/check-update/#',
-  ];
-
-  private const EXCLUDED_PATTERNS = [
-    '#^/api/security/#',
-  ];
-
   public function __construct(
     protected readonly JwtService $jwtService,
     protected readonly ConfigFactoryInterface $configFactory,
@@ -94,16 +85,22 @@ class ApiSecuritySubscriber implements EventSubscriberInterface {
    * Check if a path should be protected by JWT validation.
    */
   private function isProtectedPath(string $path): bool {
-    foreach (self::EXCLUDED_PATTERNS as $pattern) {
-      if (preg_match($pattern, $path)) {
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+
+    $excluded_raw = trim($config->get('excluded_api_patterns') ?? '');
+    foreach (array_filter(array_map('trim', explode("\n", $excluded_raw))) as $pattern) {
+      if (preg_match('#^' . $pattern . '#', $path)) {
         return FALSE;
       }
     }
-    foreach (self::PROTECTED_PATTERNS as $pattern) {
-      if (preg_match($pattern, $path)) {
+
+    $protected_raw = trim($config->get('protected_api_patterns') ?? '');
+    foreach (array_filter(array_map('trim', explode("\n", $protected_raw))) as $pattern) {
+      if (preg_match('#^' . $pattern . '#', $path)) {
         return TRUE;
       }
     }
+
     return FALSE;
   }
 

--- a/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
@@ -65,12 +65,17 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
         ],
       ],
     ];
+    $form['enforcement']['debug_logging'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable debug logging'),
+      '#description' => $this->t('Log detailed diagnostics for App Attest, Play Integrity, and JWT operations. Disable in production.'),
+      '#default_value' => $config->get('debug_logging'),
+    ];
 
     // Google Play Integrity.
     $form['google'] = [
       '#type' => 'details',
       '#title' => $this->t('Google Play Integrity'),
-      '#open' => TRUE,
     ];
     $form['google']['google_package_name'] = [
       '#type' => 'textfield',
@@ -89,8 +94,12 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       '#title' => $this->t('Verdict freshness (seconds)'),
       '#description' => $this->t('Maximum age of an integrity verdict.'),
       '#default_value' => $config->get('google_verdict_freshness_seconds'),
-      '#min' => 60,
-      '#max' => 3600,
+    ];
+    $form['google']['google_api_timeout'] = [
+      '#type' => 'number',
+      '#title' => $this->t('API timeout (seconds)'),
+      '#description' => $this->t('HTTP timeout for Google API requests.'),
+      '#default_value' => $config->get('google_api_timeout') ?: 10,
     ];
 
     // Apple App Attest.
@@ -117,26 +126,28 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       '#description' => $this->t('Uncheck for development/sandbox testing.'),
       '#default_value' => $config->get('apple_production_mode'),
     ];
+    $form['apple']['apple_root_ca_pem'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Apple App Attestation Root CA (PEM)'),
+      '#description' => $this->t('PEM-encoded root CA certificate. Download from https://www.apple.com/certificateauthority/Apple_App_Attestation_Root_CA.pem'),
+      '#default_value' => $config->get('apple_root_ca_pem'),
+      '#rows' => 14,
+    ];
 
     // Token Lifetimes.
     $form['tokens'] = [
       '#type' => 'details',
       '#title' => $this->t('Token Lifetimes'),
-      '#open' => TRUE,
     ];
     $form['tokens']['jwt_expiry_seconds'] = [
       '#type' => 'number',
       '#title' => $this->t('JWT expiry (seconds)'),
       '#default_value' => $config->get('jwt_expiry_seconds'),
-      '#min' => 300,
-      '#max' => 86400,
     ];
     $form['tokens']['refresh_expiry_seconds'] = [
       '#type' => 'number',
       '#title' => $this->t('Refresh token expiry (seconds)'),
       '#default_value' => $config->get('refresh_expiry_seconds'),
-      '#min' => 86400,
-      '#max' => 7776000,
     ];
     $form['tokens']['refresh_rotation_enabled'] = [
       '#type' => 'checkbox',
@@ -149,21 +160,70 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
     $form['rate_limiting'] = [
       '#type' => 'details',
       '#title' => $this->t('Rate Limiting'),
-      '#open' => TRUE,
     ];
     $form['rate_limiting']['register_rate_limit'] = [
       '#type' => 'number',
       '#title' => $this->t('Registration limit (per device per hour)'),
       '#default_value' => $config->get('register_rate_limit'),
-      '#min' => 1,
-      '#max' => 100,
+    ];
+    $form['rate_limiting']['device_register_ip_rate_limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Device registration limit (per IP per hour)'),
+      '#default_value' => $config->get('device_register_ip_rate_limit') ?: 5,
+    ];
+    $form['rate_limiting']['verify_rate_limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Verification limit (per device per hour)'),
+      '#default_value' => $config->get('verify_rate_limit') ?: 10,
     ];
     $form['rate_limiting']['refresh_rate_limit'] = [
       '#type' => 'number',
       '#title' => $this->t('Refresh limit (per device per hour)'),
       '#default_value' => $config->get('refresh_rate_limit'),
-      '#min' => 1,
-      '#max' => 200,
+    ];
+
+    // Operations.
+    $form['operations'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Operations'),
+    ];
+    $form['operations']['challenge_expiry_seconds'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Challenge expiry (seconds)'),
+      '#description' => $this->t('How long a sideloaded device has to respond to a challenge.'),
+      '#default_value' => $config->get('challenge_expiry_seconds') ?: 120,
+    ];
+    $form['operations']['revoked_token_retention_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Revoked token retention (days)'),
+      '#description' => $this->t('Number of days to keep revoked refresh tokens before purging.'),
+      '#default_value' => $config->get('revoked_token_retention_days') ?: 7,
+    ];
+    $form['operations']['security_log_max_entries'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum security log entries'),
+      '#description' => $this->t('Keep only the most recent N entries in the security log.'),
+      '#default_value' => $config->get('security_log_max_entries') ?: 10000,
+    ];
+
+    // API Protection.
+    $form['api_protection'] = [
+      '#type' => 'details',
+      '#title' => $this->t('API Protection'),
+    ];
+    $form['api_protection']['protected_api_patterns'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Protected API route patterns'),
+      '#description' => $this->t('One pattern per line. Routes matching these require JWT validation. Example: /v2/api/'),
+      '#default_value' => $config->get('protected_api_patterns'),
+      '#rows' => 4,
+    ];
+    $form['api_protection']['excluded_api_patterns'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Excluded API route patterns'),
+      '#description' => $this->t('One pattern per line. These routes skip JWT even if they match a protected pattern. Example: /api/security/'),
+      '#default_value' => $config->get('excluded_api_patterns'),
+      '#rows' => 4,
     ];
 
     return parent::buildForm($form, $form_state);
@@ -187,6 +247,53 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
         }
       }
     }
+
+    $pem = trim($form_state->getValue('apple_root_ca_pem') ?? '');
+    if (!empty($pem) && !str_contains($pem, '-----BEGIN CERTIFICATE-----')) {
+      $form_state->setErrorByName('apple_root_ca_pem', $this->t('Invalid PEM: must contain -----BEGIN CERTIFICATE----- header.'));
+    }
+
+    $numeric_ranges = [
+      'google_verdict_freshness_seconds' => [60, 3600],
+      'google_api_timeout' => [5, 30],
+      'jwt_expiry_seconds' => [300, 86400],
+      'refresh_expiry_seconds' => [86400, 7776000],
+      'register_rate_limit' => [1, 100],
+      'device_register_ip_rate_limit' => [1, 50],
+      'verify_rate_limit' => [1, 100],
+      'refresh_rate_limit' => [1, 200],
+      'challenge_expiry_seconds' => [30, 600],
+      'revoked_token_retention_days' => [1, 90],
+      'security_log_max_entries' => [1000, 100000],
+    ];
+    foreach ($numeric_ranges as $field => [$min, $max]) {
+      $val = $form_state->getValue($field);
+      if ($val !== '' && $val !== NULL && (string) $val !== '0' && !empty($val) && ((int) $val < $min || (int) $val > $max)) {
+        $form_state->setErrorByName($field, $this->t('Value must be between @min and @max.', [
+          '@min' => $min,
+          '@max' => $max,
+        ]));
+      }
+    }
+
+    $this->validatePatternField($form_state, 'protected_api_patterns');
+    $this->validatePatternField($form_state, 'excluded_api_patterns');
+  }
+
+  /**
+   * Validate that each line in a textarea field is a valid regex pattern.
+   */
+  private function validatePatternField(FormStateInterface $form_state, string $field): void {
+    $raw = trim($form_state->getValue($field) ?? '');
+    if (empty($raw)) {
+      return;
+    }
+    foreach (array_filter(array_map('trim', explode("\n", $raw))) as $pattern) {
+      if (@preg_match('#^' . $pattern . '#', '') === FALSE) {
+        $form_state->setErrorByName($field, $this->t('Invalid regex pattern: @pattern', ['@pattern' => $pattern]));
+        break;
+      }
+    }
   }
 
   /**
@@ -199,17 +306,27 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       ->set('enforcement_mode', $form_state->getValue('enforcement_mode'))
       ->set('dev_bypass_enabled', (bool) $form_state->getValue('dev_bypass_enabled'))
       ->set('dev_bypass_ips', $form_state->getValue('dev_bypass_ips'))
+      ->set('debug_logging', (bool) $form_state->getValue('debug_logging'))
       ->set('google_package_name', $form_state->getValue('google_package_name'))
       ->set('google_project_number', $form_state->getValue('google_project_number'))
       ->set('google_verdict_freshness_seconds', (int) $form_state->getValue('google_verdict_freshness_seconds'))
+      ->set('google_api_timeout', (int) $form_state->getValue('google_api_timeout'))
       ->set('apple_team_id', $form_state->getValue('apple_team_id'))
       ->set('apple_bundle_id', $form_state->getValue('apple_bundle_id'))
       ->set('apple_production_mode', (bool) $form_state->getValue('apple_production_mode'))
+      ->set('apple_root_ca_pem', trim($form_state->getValue('apple_root_ca_pem') ?? ''))
       ->set('jwt_expiry_seconds', (int) $form_state->getValue('jwt_expiry_seconds'))
       ->set('refresh_expiry_seconds', (int) $form_state->getValue('refresh_expiry_seconds'))
       ->set('refresh_rotation_enabled', (bool) $form_state->getValue('refresh_rotation_enabled'))
       ->set('register_rate_limit', (int) $form_state->getValue('register_rate_limit'))
+      ->set('device_register_ip_rate_limit', (int) $form_state->getValue('device_register_ip_rate_limit'))
+      ->set('verify_rate_limit', (int) $form_state->getValue('verify_rate_limit'))
       ->set('refresh_rate_limit', (int) $form_state->getValue('refresh_rate_limit'))
+      ->set('challenge_expiry_seconds', (int) $form_state->getValue('challenge_expiry_seconds'))
+      ->set('revoked_token_retention_days', (int) $form_state->getValue('revoked_token_retention_days'))
+      ->set('security_log_max_entries', (int) $form_state->getValue('security_log_max_entries'))
+      ->set('protected_api_patterns', trim($form_state->getValue('protected_api_patterns') ?? ''))
+      ->set('excluded_api_patterns', trim($form_state->getValue('excluded_api_patterns') ?? ''))
       ->save();
   }
 

--- a/docroot/modules/custom/bebbo_api_security/src/Service/AppleAppAttestService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/AppleAppAttestService.php
@@ -23,25 +23,6 @@ class AppleAppAttestService {
 
   private const AAGUID_DEVELOPMENT = "appattestdevelop";
 
-  // @codingStandardsIgnoreStart
-  private const APPLE_ROOT_CA_PEM = <<<'PEM'
------BEGIN CERTIFICATE-----
-MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
-JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
-QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
-Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
-biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
-bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
-NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDnzczMhM7Q8F2Iv+vha1sJQo/GKF6MIgcDm
-ouxUBEezky0IX5b+8/PCjR3TJQr90U0qo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0G
-A1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYwCgYI
-KoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn53O5
-+FRXgeLhd/U3DGMSr0G7AjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijVoyFr
-aWVIyd/dganmrduC1bmTBGwD
------END CERTIFICATE-----
-PEM;
-  // @codingStandardsIgnoreEnd
-
   /**
    * Constructs an AppleAppAttestService object.
    *
@@ -140,7 +121,16 @@ PEM;
     $leaf_der = $x5c[0];
     $intermediate_der = $x5c[1];
 
-    $this->verifyCertificateChain($leaf_der, $intermediate_der);
+    $debug = (bool) $config->get('debug_logging');
+    if ($debug) {
+      $this->logger->debug('App Attest cert chain: x5c has @count certs, leaf DER @leaf_len bytes, intermediate DER @inter_len bytes.', [
+        '@count' => count($x5c),
+        '@leaf_len' => strlen($leaf_der),
+        '@inter_len' => strlen($intermediate_der),
+      ]);
+    }
+
+    $this->verifyCertificateChain($leaf_der, $intermediate_der, $debug);
 
     // Verify nonce in leaf certificate.
     $nonce = hash('sha256', $auth_data . hex2bin($client_data_hash), TRUE);
@@ -279,36 +269,134 @@ PEM;
    *   DER-encoded leaf certificate.
    * @param string $intermediate_der
    *   DER-encoded intermediate certificate.
+   * @param bool $debug
+   *   Whether to log detailed diagnostic information.
    *
    * @throws \RuntimeException
    *   If chain verification fails.
    */
-  private function verifyCertificateChain(string $leaf_der, string $intermediate_der): void {
+  private function verifyCertificateChain(string $leaf_der, string $intermediate_der, bool $debug): void {
     $leaf_pem = $this->derToPem($leaf_der, 'CERTIFICATE');
     $intermediate_pem = $this->derToPem($intermediate_der, 'CERTIFICATE');
 
+    $root_ca_pem = $this->configFactory->get('bebbo_api_security.settings')
+      ->get('apple_root_ca_pem');
+    if (empty($root_ca_pem)) {
+      throw new \RuntimeException('Apple Root CA PEM not configured. Set it in API Security settings.');
+    }
+
     $leaf_cert = openssl_x509_read($leaf_pem);
     if (!$leaf_cert) {
+      $this->logger->error('App Attest: failed to parse leaf certificate. OpenSSL error: @err', [
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
       throw new \RuntimeException('Failed to parse leaf certificate.');
     }
 
     $intermediate_cert = openssl_x509_read($intermediate_pem);
     if (!$intermediate_cert) {
+      $this->logger->error('App Attest: failed to parse intermediate certificate. OpenSSL error: @err', [
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
       throw new \RuntimeException('Failed to parse intermediate certificate.');
     }
 
-    $root_cert = openssl_x509_read(self::APPLE_ROOT_CA_PEM);
+    $root_cert = openssl_x509_read($root_ca_pem);
+    if (!$root_cert) {
+      $this->logger->error('App Attest: failed to parse configured root CA PEM. OpenSSL error: @err', [
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
+      throw new \RuntimeException('Failed to parse Apple Root CA certificate from config.');
+    }
+
+    if ($debug) {
+      $leaf_parsed = openssl_x509_parse($leaf_cert);
+      $inter_parsed = openssl_x509_parse($intermediate_cert);
+      $root_parsed = openssl_x509_parse($root_cert);
+
+      $this->logger->debug('App Attest cert subjects — leaf: @leaf_subj (issuer: @leaf_iss), intermediate: @inter_subj (issuer: @inter_iss), root: @root_subj (issuer: @root_iss).', [
+        '@leaf_subj' => $leaf_parsed['subject']['CN'] ?? 'unknown',
+        '@leaf_iss' => $leaf_parsed['issuer']['CN'] ?? 'unknown',
+        '@inter_subj' => $inter_parsed['subject']['CN'] ?? 'unknown',
+        '@inter_iss' => $inter_parsed['issuer']['CN'] ?? 'unknown',
+        '@root_subj' => $root_parsed['subject']['CN'] ?? 'unknown',
+        '@root_iss' => $root_parsed['issuer']['CN'] ?? 'unknown',
+      ]);
+
+      $this->logger->debug('App Attest cert validity — leaf: @leaf_from to @leaf_to, intermediate: @inter_from to @inter_to.', [
+        '@leaf_from' => date('Y-m-d H:i:s', $leaf_parsed['validFrom_time_t'] ?? 0),
+        '@leaf_to' => date('Y-m-d H:i:s', $leaf_parsed['validTo_time_t'] ?? 0),
+        '@inter_from' => date('Y-m-d H:i:s', $inter_parsed['validFrom_time_t'] ?? 0),
+        '@inter_to' => date('Y-m-d H:i:s', $inter_parsed['validTo_time_t'] ?? 0),
+      ]);
+
+      $this->logger->debug('App Attest cert algorithms — leaf: @leaf_algo, intermediate: @inter_algo, root: @root_algo.', [
+        '@leaf_algo' => $leaf_parsed['signatureTypeSN'] ?? 'unknown',
+        '@inter_algo' => $inter_parsed['signatureTypeSN'] ?? 'unknown',
+        '@root_algo' => $root_parsed['signatureTypeSN'] ?? 'unknown',
+      ]);
+    }
 
     // Verify leaf is signed by intermediate.
-    $result = openssl_x509_verify($leaf_cert, openssl_pkey_get_public($intermediate_cert));
+    $inter_key = openssl_pkey_get_public($intermediate_cert);
+    if (!$inter_key) {
+      $this->logger->error('App Attest: failed to extract public key from intermediate cert. OpenSSL error: @err', [
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
+      throw new \RuntimeException('Failed to extract public key from intermediate certificate.');
+    }
+
+    if ($debug) {
+      $inter_key_details = openssl_pkey_get_details($inter_key);
+      $this->logger->debug('App Attest intermediate key — type: @type, bits: @bits.', [
+        '@type' => $inter_key_details['type'] ?? 'unknown',
+        '@bits' => $inter_key_details['bits'] ?? 'unknown',
+      ]);
+    }
+
+    $result = openssl_x509_verify($leaf_cert, $inter_key);
     if ($result !== 1) {
+      $this->logger->error('App Attest: leaf not signed by intermediate. openssl_x509_verify returned @result (1=ok, 0=mismatch, -1=error). OpenSSL error: @err', [
+        '@result' => $result,
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
       throw new \RuntimeException('Leaf certificate not signed by intermediate.');
     }
 
+    if ($debug) {
+      $this->logger->debug('App Attest: leaf → intermediate signature verified OK.');
+    }
+
     // Verify intermediate is signed by Apple Root CA.
-    $result = openssl_x509_verify($intermediate_cert, openssl_pkey_get_public($root_cert));
+    $root_key = openssl_pkey_get_public($root_cert);
+    if (!$root_key) {
+      $this->logger->error('App Attest: failed to extract public key from root CA. OpenSSL error: @err', [
+        '@err' => openssl_error_string() ?: 'none',
+      ]);
+      throw new \RuntimeException('Failed to extract public key from Apple Root CA.');
+    }
+
+    if ($debug) {
+      $root_key_details = openssl_pkey_get_details($root_key);
+      $this->logger->debug('App Attest root CA key — type: @type, bits: @bits.', [
+        '@type' => $root_key_details['type'] ?? 'unknown',
+        '@bits' => $root_key_details['bits'] ?? 'unknown',
+      ]);
+    }
+
+    $result = openssl_x509_verify($intermediate_cert, $root_key);
     if ($result !== 1) {
+      $inter_parsed = $inter_parsed ?? openssl_x509_parse($intermediate_cert);
+      $this->logger->error('App Attest: intermediate not signed by root CA. openssl_x509_verify returned @result (1=ok, 0=mismatch, -1=error). OpenSSL error: @err. Intermediate issuer CN: @issuer.', [
+        '@result' => $result,
+        '@err' => openssl_error_string() ?: 'none',
+        '@issuer' => $inter_parsed['issuer']['CN'] ?? 'unknown',
+      ]);
       throw new \RuntimeException('Intermediate certificate not signed by Apple Root CA.');
+    }
+
+    if ($debug) {
+      $this->logger->debug('App Attest: intermediate → root CA signature verified OK.');
     }
   }
 

--- a/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\bebbo_api_security\Service;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerInterface;
 
@@ -12,9 +13,20 @@ use Psr\Log\LoggerInterface;
  */
 class DeviceRegistryService {
 
+  /**
+   * Constructs a DeviceRegistryService.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
   public function __construct(
     protected readonly Connection $database,
     protected readonly LoggerInterface $logger,
+    protected readonly ConfigFactoryInterface $configFactory,
   ) {}
 
   /**
@@ -100,19 +112,22 @@ class DeviceRegistryService {
       ->condition('expires', $now, '<')
       ->execute();
 
+    $config = $this->configFactory->get('bebbo_api_security.settings');
+    $retention_days = (int) $config->get('revoked_token_retention_days') ?: 7;
     $stats['tokens_revoked'] = $this->database->delete('bebbo_api_refresh_tokens')
       ->condition('revoked', 1)
-      ->condition('created', $now - 604800, '<')
+      ->condition('created', $now - ($retention_days * 86400), '<')
       ->execute();
 
     $stats['tokens_expired'] = $this->database->delete('bebbo_api_refresh_tokens')
       ->condition('expires', $now, '<')
       ->execute();
 
+    $max_entries = (int) $config->get('security_log_max_entries') ?: 10000;
     $max_id = $this->database->select('bebbo_api_security_log', 'l')
       ->fields('l', ['id'])
       ->orderBy('id', 'DESC')
-      ->range(10000, 1)
+      ->range($max_entries, 1)
       ->execute()
       ->fetchField();
 

--- a/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
@@ -75,6 +75,7 @@ class GooglePlayIntegrityService {
     }
 
     $access_token = $this->getGoogleAccessToken();
+    $timeout = (int) $config->get('google_api_timeout') ?: 10;
 
     try {
       $response = $this->httpClient->request('POST',
@@ -85,7 +86,7 @@ class GooglePlayIntegrityService {
             'Content-Type' => 'application/json',
           ],
           'json' => ['integrity_token' => $integrity_token],
-          'timeout' => 10,
+          'timeout' => $timeout,
         ]
       );
     }
@@ -201,13 +202,14 @@ class GooglePlayIntegrityService {
 
     $assertion = JWT::encode($jwt_payload, $sa_json['private_key'], 'RS256');
 
+    $timeout = (int) $this->configFactory->get('bebbo_api_security.settings')->get('google_api_timeout') ?: 10;
     try {
       $response = $this->httpClient->request('POST', 'https://oauth2.googleapis.com/token', [
         'form_params' => [
           'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
           'assertion' => $assertion,
         ],
-        'timeout' => 10,
+        'timeout' => $timeout,
       ]);
     }
     catch (GuzzleException $e) {

--- a/docroot/modules/custom/bebbo_api_security/src/Service/SideloadedVerificationService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/SideloadedVerificationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\bebbo_api_security\Service;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerInterface;
 
@@ -19,10 +20,13 @@ class SideloadedVerificationService {
    *   The database connection.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger channel.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
    */
   public function __construct(
     protected readonly Connection $database,
     protected readonly LoggerInterface $logger,
+    protected readonly ConfigFactoryInterface $configFactory,
   ) {}
 
   /**
@@ -67,7 +71,7 @@ class SideloadedVerificationService {
       'device_id' => $device_id,
       'challenge' => $challenge,
       'purpose' => 'sideloaded_verify',
-      'expires' => time() + 120,
+      'expires' => time() + ((int) $this->configFactory->get('bebbo_api_security.settings')->get('challenge_expiry_seconds') ?: 120),
       'used' => 0,
       'created' => time(),
     ])->execute();


### PR DESCRIPTION
- Move Apple Root CA PEM from PHP constant to admin config textarea
- Add debug logging toggle (gates diagnostic logs behind checkbox)
- Move rate limits, challenge expiry, Google API timeout, log retention, and API route patterns from hardcoded values to config
- Fix bug: controller was ignoring existing register_rate_limit and refresh_rate_limit config values, using hardcoded numbers instead
- Remove HTML5 min/max validation to fix not-focusable error on collapsed details sections, replace with server-side validation
- Close all form sections except Enforcement Mode by default
- Inject ConfigFactoryInterface into SideloadedVerificationService and DeviceRegistryService