### PR TITLE
fix: device re-registration UPSERT and admin table cleanup buttons

### DIFF
--- a/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
@@ -4,13 +4,31 @@ declare(strict_types=1);
 
 namespace Drupal\bebbo_api_security\Form;
 
+use Drupal\bebbo_api_security\Service\DeviceRegistryService;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Admin configuration form for API security settings.
  */
 class ApiSecuritySettingsForm extends ConfigFormBase {
+
+  /**
+   * The device registry service.
+   *
+   * @var \Drupal\bebbo_api_security\Service\DeviceRegistryService
+   */
+  protected DeviceRegistryService $registry;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->registry = $container->get('bebbo_api_security.device_registry');
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -226,6 +244,36 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       '#rows' => 4,
     ];
 
+    // Data Management.
+    $form['data_management'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Data Management'),
+    ];
+    $form['data_management']['purge_expired'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Purge Expired Data'),
+      '#description' => $this->t('Remove expired challenges, revoked tokens, and trim security log per retention settings above.'),
+      '#submit' => ['::purgeExpiredSubmit'],
+      '#limit_validation_errors' => [],
+      '#attributes' => ['class' => ['button']],
+    ];
+    $form['data_management']['purge_description'] = [
+      '#markup' => '<p>' . $this->t('Remove expired challenges, revoked/expired tokens, and trim the security log per retention settings.') . '</p>',
+    ];
+    $form['data_management']['truncate_all'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Truncate All Security Tables'),
+      '#submit' => ['::truncateAllSubmit'],
+      '#limit_validation_errors' => [],
+      '#attributes' => [
+        'class' => ['button', 'button--danger'],
+        'onclick' => 'return confirm("This will permanently delete ALL data from devices, challenges, tokens, and security log tables. Auto-increment resets to 1. This cannot be undone. Continue?")',
+      ],
+    ];
+    $form['data_management']['truncate_description'] = [
+      '#markup' => '<p>' . $this->t('Delete ALL data from devices, challenges, tokens, and security log. Auto-increment resets to 1. <strong>Cannot be undone.</strong>') . '</p>',
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -328,6 +376,32 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       ->set('protected_api_patterns', trim($form_state->getValue('protected_api_patterns') ?? ''))
       ->set('excluded_api_patterns', trim($form_state->getValue('excluded_api_patterns') ?? ''))
       ->save();
+  }
+
+  /**
+   * Submit handler for the "Purge Expired Data" button.
+   */
+  public function purgeExpiredSubmit(array &$form, FormStateInterface $form_state): void {
+    $stats = $this->registry->purgeExpired();
+    $this->messenger()->addStatus($this->t('Purged: @challenges expired challenges, @revoked revoked tokens, @expired expired tokens, @logs old log entries.', [
+      '@challenges' => $stats['challenges'],
+      '@revoked' => $stats['tokens_revoked'],
+      '@expired' => $stats['tokens_expired'],
+      '@logs' => $stats['logs'],
+    ]));
+  }
+
+  /**
+   * Submit handler for the "Truncate All Security Tables" button.
+   */
+  public function truncateAllSubmit(array &$form, FormStateInterface $form_state): void {
+    $stats = $this->registry->truncateAll();
+    $this->messenger()->addWarning($this->t('Truncated all security tables: @devices devices, @challenges challenges, @tokens refresh tokens, @logs log entries removed.', [
+      '@devices' => $stats['devices'],
+      '@challenges' => $stats['challenges'],
+      '@tokens' => $stats['tokens'],
+      '@logs' => $stats['logs'],
+    ]));
   }
 
 }

--- a/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/DeviceRegistryService.php
@@ -30,14 +30,33 @@ class DeviceRegistryService {
   ) {}
 
   /**
-   * Insert a new device record.
+   * Register or re-register a device (UPSERT).
+   *
+   * On re-registration, preserves the original created timestamp and
+   * invalidates any existing refresh tokens and challenges.
    *
    * @return int
-   *   The auto-increment ID of the inserted row.
+   *   Merge status constant.
    */
   public function registerDevice(array $fields): int {
-    return (int) $this->database->insert('bebbo_api_devices')
-      ->fields($fields)
+    $device_id = $fields['device_id'];
+
+    // Invalidate stale tokens and challenges on re-registration.
+    $this->database->delete('bebbo_api_refresh_tokens')
+      ->condition('device_id', $device_id)
+      ->execute();
+    $this->database->delete('bebbo_api_challenges')
+      ->condition('device_id', $device_id)
+      ->execute();
+
+    // Preserve original created timestamp on update.
+    $update_fields = $fields;
+    unset($update_fields['device_id'], $update_fields['created']);
+
+    return (int) $this->database->merge('bebbo_api_devices')
+      ->keys(['device_id' => $device_id])
+      ->fields($update_fields)
+      ->insertFields(['created' => $fields['created'] ?? time()])
       ->execute();
   }
 
@@ -138,6 +157,30 @@ class DeviceRegistryService {
         ->execute();
     }
 
+    return $stats;
+  }
+
+  /**
+   * Truncate all security tables, resetting auto-increment counters.
+   *
+   * @return array
+   *   Row counts per table before truncation.
+   */
+  public function truncateAll(): array {
+    $tables = [
+      'devices' => 'bebbo_api_devices',
+      'challenges' => 'bebbo_api_challenges',
+      'tokens' => 'bebbo_api_refresh_tokens',
+      'logs' => 'bebbo_api_security_log',
+    ];
+    $stats = [];
+    foreach ($tables as $key => $table) {
+      $stats[$key] = (int) $this->database->select($table)
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+      $this->database->truncate($table)->execute();
+    }
     return $stats;
   }
 


### PR DESCRIPTION
Device re-registration (app reinstall, key rotation) failed with duplicate key error because registerDevice() used INSERT instead of UPSERT. Changed to merge() to update existing rows, preserve original created timestamp, and invalidate stale tokens/challenges.

Added Data Management section to API Security settings form with Purge Expired and Truncate All buttons for table maintenance.