### PR TITLE
fix: pass Play Integrity nonce verbatim, remove SHA-256 hashing

### DIFF
--- a/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Controller/SecurityController.php
@@ -92,10 +92,7 @@ class SecurityController extends ControllerBase {
             'message' => 'integrity_token is required for Android.',
           ], 400);
         }
-        $expected_hash = NULL;
-        if (!empty($body['nonce'])) {
-          $expected_hash = rtrim(strtr(base64_encode(hash('sha256', $body['nonce'], TRUE)), '+/', '-_'), '=');
-        }
+        $expected_hash = !empty($body['nonce']) ? $body['nonce'] : NULL;
         $this->googleService->verifyToken($body['integrity_token'], $device_id, $expected_hash);
         $auth_method = 'play_integrity';
 

--- a/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
@@ -103,7 +103,7 @@ class GooglePlayIntegrityService {
     }
 
     if ($expected_request_hash === NULL) {
-      $expected_request_hash = rtrim(strtr(base64_encode(hash('sha256', $device_id, TRUE)), '+/', '-_'), '=');
+      $expected_request_hash = $device_id;
     }
 
     $this->verifyVerdicts($payload, $device_id, $expected_request_hash);
@@ -119,7 +119,7 @@ class GooglePlayIntegrityService {
    * @param string $device_id
    *   Device identifier for error context.
    * @param string $expected_request_hash
-   *   Base64url-encoded SHA-256 hash the app used as nonce.
+   *   The challenge string the app passed verbatim as nonce.
    *
    * @throws \RuntimeException
    *   If any verdict check fails.


### PR DESCRIPTION
Mobile now sends the challenge directly as nonce — no hashing on either side. SHA-256 double-hashing caused encoding mismatches with no security benefit since the challenge is already cryptographically strong.