### PR TITLE
fix: read nonce from Classic API field, not Standard API requestHash

### DIFF
--- a/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
@@ -140,14 +140,14 @@ class GooglePlayIntegrityService {
 
     $details = $payload['tokenPayloadExternal'] ?? [];
 
-    // Verify requestHash — binds the integrity token to this registration.
-    $actual_hash = $details['requestDetails']['requestHash'] ?? '';
-    $this->logger->debug('Nonce comparison — expected: @expected | actual requestHash: @actual', [
+    // Verify nonce — binds integrity token to this request.
+    $actual_nonce = $details['requestDetails']['nonce'] ?? '';
+    $this->logger->debug('Nonce comparison — expected: @expected | actual nonce: @actual', [
       '@expected' => $expected_request_hash,
-      '@actual' => $actual_hash,
+      '@actual' => $actual_nonce,
     ]);
-    if (!hash_equals($expected_request_hash, $actual_hash)) {
-      throw new \RuntimeException('requestHash mismatch: integrity token not bound to this request.');
+    if (!hash_equals($expected_request_hash, $actual_nonce)) {
+      throw new \RuntimeException('Nonce mismatch: integrity token not bound to this request.');
     }
 
     // Verify package name.


### PR DESCRIPTION
Classic Play Integrity API returns the nonce in requestDetails.nonce, not requestDetails.requestHash (Standard API). This was causing mismatches — the field was empty while the actual nonce was correct.