### PR TITLE
feat: add toggle to accept UNRECOGNIZED_VERSION verdict

### DIFF
--- a/config/sync/bebbo_api_security.settings.yml
+++ b/config/sync/bebbo_api_security.settings.yml
@@ -6,6 +6,7 @@ dev_bypass_ips: ''
 google_package_name: ''
 google_project_number: ''
 google_verdict_freshness_seconds: 600
+google_allow_unrecognized_version: false
 apple_team_id: ''
 apple_bundle_id: ''
 apple_production_mode: true

--- a/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/install/bebbo_api_security.settings.yml
@@ -16,6 +16,7 @@ apple_root_ca_pem: ''
 debug_logging: false
 challenge_expiry_seconds: 120
 google_api_timeout: 10
+google_allow_unrecognized_version: false
 device_register_ip_rate_limit: 5
 verify_rate_limit: 10
 revoked_token_retention_days: 7

--- a/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
+++ b/docroot/modules/custom/bebbo_api_security/config/schema/bebbo_api_security.schema.yml
@@ -56,6 +56,9 @@ bebbo_api_security.settings:
     google_api_timeout:
       type: integer
       label: 'Google API HTTP timeout in seconds'
+    google_allow_unrecognized_version:
+      type: boolean
+      label: 'Accept UNRECOGNIZED_VERSION app verdict (dev/testing only)'
     device_register_ip_rate_limit:
       type: integer
       label: 'Device registration rate limit per IP per hour'

--- a/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Form/ApiSecuritySettingsForm.php
@@ -119,6 +119,12 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       '#description' => $this->t('HTTP timeout for Google API requests.'),
       '#default_value' => $config->get('google_api_timeout') ?: 10,
     ];
+    $form['google']['google_allow_unrecognized_version'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Accept UNRECOGNIZED_VERSION app verdict'),
+      '#description' => $this->t('Dev/testing only — allows sideloaded debug builds (adb installs) that Google has not published. Every acceptance is logged as a warning. <strong>Never enable in production.</strong>'),
+      '#default_value' => $config->get('google_allow_unrecognized_version'),
+    ];
 
     // Apple App Attest.
     $form['apple'] = [
@@ -359,6 +365,7 @@ class ApiSecuritySettingsForm extends ConfigFormBase {
       ->set('google_project_number', $form_state->getValue('google_project_number'))
       ->set('google_verdict_freshness_seconds', (int) $form_state->getValue('google_verdict_freshness_seconds'))
       ->set('google_api_timeout', (int) $form_state->getValue('google_api_timeout'))
+      ->set('google_allow_unrecognized_version', (bool) $form_state->getValue('google_allow_unrecognized_version'))
       ->set('apple_team_id', $form_state->getValue('apple_team_id'))
       ->set('apple_bundle_id', $form_state->getValue('apple_bundle_id'))
       ->set('apple_production_mode', (bool) $form_state->getValue('apple_production_mode'))

--- a/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
+++ b/docroot/modules/custom/bebbo_api_security/src/Service/GooglePlayIntegrityService.php
@@ -178,8 +178,17 @@ class GooglePlayIntegrityService {
 
     // Verify app recognition.
     $app_verdict = $details['appIntegrity']['appRecognitionVerdict'] ?? 'UNEVALUATED';
-    if ($app_verdict !== 'PLAY_RECOGNIZED') {
+    $allowed_verdicts = ['PLAY_RECOGNIZED'];
+    if ((bool) $config->get('google_allow_unrecognized_version')) {
+      $allowed_verdicts[] = 'UNRECOGNIZED_VERSION';
+    }
+    if (!in_array($app_verdict, $allowed_verdicts, TRUE)) {
       throw new \RuntimeException("App not recognized by Play Store: {$app_verdict}");
+    }
+    if ($app_verdict === 'UNRECOGNIZED_VERSION') {
+      $this->logger->warning('Accepted UNRECOGNIZED_VERSION app verdict for device @device — google_allow_unrecognized_version is enabled. This must be off in production.', [
+        '@device' => $device_id,
+      ]);
     }
   }
 

--- a/docroot/modules/custom/bebbo_api_security/tests/src/Unit/GooglePlayIntegrityServiceTest.php
+++ b/docroot/modules/custom/bebbo_api_security/tests/src/Unit/GooglePlayIntegrityServiceTest.php
@@ -217,6 +217,78 @@ class GooglePlayIntegrityServiceTest extends TestCase {
   }
 
   /**
+   * Build a payload that passes every check except app recognition.
+   */
+  private function buildUnrecognizedVersionPayload(string $nonce): array {
+    return [
+      'tokenPayloadExternal' => [
+        'requestDetails' => [
+          'requestPackageName' => 'org.unicef.bebbo',
+          'timestampMillis' => (string) (time() * 1000),
+          'nonce' => $nonce,
+        ],
+        'deviceIntegrity' => [
+          'deviceRecognitionVerdict' => ['MEETS_DEVICE_INTEGRITY'],
+        ],
+        'appIntegrity' => [
+          'appRecognitionVerdict' => 'UNRECOGNIZED_VERSION',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsRejectsUnrecognizedVersionByDefault(): void {
+    $nonce = bin2hex(random_bytes(32));
+    $payload = $this->buildUnrecognizedVersionPayload($nonce);
+
+    $method = new \ReflectionMethod($this->service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('not recognized by Play Store');
+    $method->invoke($this->service, $payload, 'test-device', $nonce);
+  }
+
+  /**
+   * @covers ::verifyVerdicts
+   */
+  public function testVerifyVerdictsAcceptsUnrecognizedVersionWhenToggled(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnMap([
+      ['google_package_name', 'org.unicef.bebbo'],
+      ['google_verdict_freshness_seconds', 600],
+      ['google_allow_unrecognized_version', TRUE],
+    ]);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')
+      ->with('bebbo_api_security.settings')
+      ->willReturn($config);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())->method('warning');
+
+    $service = new GooglePlayIntegrityService(
+      $this->createMock(ClientInterface::class),
+      $this->createMock(KeyRepositoryInterface::class),
+      $configFactory,
+      $logger,
+    );
+
+    $nonce = bin2hex(random_bytes(32));
+    $payload = $this->buildUnrecognizedVersionPayload($nonce);
+
+    $method = new \ReflectionMethod($service, 'verifyVerdicts');
+    $method->setAccessible(TRUE);
+
+    // Should not throw.
+    $method->invoke($service, $payload, 'test-device', $nonce);
+    $this->assertTrue(TRUE);
+  }
+
+  /**
    * @covers ::verifyVerdicts
    */
   public function testVerifyVerdictsRejectsWrongRequestHash(): void {


### PR DESCRIPTION
Sideloaded debug builds (adb installs) always get UNRECOGNIZED_VERSION from Play Integrity, blocking app-team testing on dev. Off by default; every acceptance is logged as a warning so a production misconfiguration is visible. Enable via the settings form on dev only.