### PR TITLE
Misc Drupal 11 fixes for groups.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
         "drupal/toolbar_menu_clean": "^2.0",
         "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/upgrade_status": "^4.3",
-        "drupal/variationcache": "^1.5",
         "drupal/video_embed_field": "^3.1",
         "drupal/video_embed_media": "^2.4",
         "drupal/view_custom_table": "2.0.8",
@@ -273,7 +272,6 @@
             "allowed-list": [
                 "drupal/filelog",
                 "drupal/entity_share_cron",
-                "drupal/variationcache",
                 "drupal/imageapi_optimize_gd",
                 "drupal/imageapi_optimize_avif_webp",
                 "drupal/color",
@@ -323,7 +321,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^11.5",
         "symfony/phpunit-bridge": "^6.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1da0ba36aad903d9f08c67f34dc5872d",
+    "content-hash": "41e1dde8ec8dfd4e632834981d1b5f28",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -9362,57 +9362,6 @@
             }
         },
         {
-            "name": "drupal/variationcache",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/variationcache.git",
-                "reference": "8.x-1.5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/variationcache-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "6165baee8c6fe5a7773f3499896e8fb464607a32"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9 || ^10 || ^11 || ^12"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1705485386",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Kristiaan Van den Eynde",
-                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Brad Jones",
-                    "homepage": "https://www.drupal.org/u/bradjones1",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "This project provides VariationCache, a redirect-aware caching implementation.",
-            "homepage": "http://drupal.org/project/variationcache",
-            "support": {
-                "source": "https://git.drupalcode.org/project/variationcache",
-                "issues": "https://drupal.org/project/issues/variationcache"
-            }
-        },
-        {
             "name": "drupal/video_embed_field",
             "version": "3.1.0",
             "source": {
@@ -14253,29 +14202,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^11.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -14307,7 +14256,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -14315,7 +14265,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "spomky-labs/cbor-php",
@@ -19281,35 +19231,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -19318,7 +19268,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -19347,40 +19297,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -19407,36 +19369,49 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -19444,7 +19419,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -19470,7 +19445,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -19478,32 +19454,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -19529,7 +19505,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -19537,32 +19514,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -19588,7 +19565,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -19596,24 +19574,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "11.5.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -19623,27 +19600,27 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.10",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -19651,7 +19628,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -19683,7 +19660,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
             },
             "funding": [
                 {
@@ -19707,32 +19684,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-02-18T12:37:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -19755,7 +19732,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -19763,32 +19741,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -19811,7 +19789,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -19819,32 +19798,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -19866,7 +19845,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -19874,34 +19854,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.10",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -19940,7 +19925,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -19960,33 +19946,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:22:56+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -20009,7 +19995,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -20017,27 +20004,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -20045,7 +20032,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -20064,7 +20051,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -20072,42 +20059,55 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -20149,7 +20149,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
@@ -20169,38 +20170,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -20219,59 +20217,48 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -20294,7 +20281,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -20302,34 +20290,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -20351,7 +20339,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -20359,32 +20348,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -20406,7 +20395,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -20414,32 +20404,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -20469,7 +20459,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
             },
             "funding": [
                 {
@@ -20489,86 +20480,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-13T04:42:22+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -20591,37 +20528,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2025-08-09T06:55:48+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -20644,7 +20594,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -20652,7 +20603,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -20853,6 +20804,58 @@
                 }
             ],
             "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/cache",

--- a/config/sync/views.view.bebbo_v2_apis.yml
+++ b/config/sync/views.view.bebbo_v2_apis.yml
@@ -20929,8 +20929,8 @@ display:
           label: ''
           exclude: true
           alter:
-            alter_text: true
-            text: '{{ field_featured_image_1|number_format }}'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false

--- a/config/sync/views.view.group_members.yml
+++ b/config/sync/views.view.group_members.yml
@@ -573,7 +573,7 @@ display:
             group_roles: '0'
             changed: '0'
             created: '0'
-            delete_group_relationship: '0'
+            delete_group_relationship: delete_group_relationship
       pager:
         type: full
         options:

--- a/docroot/modules/custom/bebbo_serializer/js/quiz_question_count.js
+++ b/docroot/modules/custom/bebbo_serializer/js/quiz_question_count.js
@@ -38,15 +38,18 @@
     }
 
     var isSingle = getQuizType() === SINGLE_QUESTION;
+    var count = getQuestionCount();
 
-    // Hide/show the "Add new Quiz Question" button.
-    $wrapper.find('input[name*="-add"]').toggle(!isSingle);
+    // Show the "Add new Quiz Question" button unless this is a single question
+    // quiz that already has its one question. A single quiz with no question
+    // yet still needs the button to add that one required question.
+    $wrapper.find('input[name*="-add"]').toggle(!isSingle || count === 0);
 
     // Hide/show duplicate buttons in entity operation cells.
     $wrapper.find('.ief-entity-operations input[name*="entity-duplicate"]').toggle(!isSingle);
 
     // Auto-remove extra entities for single question quiz.
-    if (isSingle && !removing && !pendingConfirm && getQuestionCount() > 1) {
+    if (isSingle && !removing && !pendingConfirm && count > 1) {
       removeLastEntity($wrapper);
     }
   }

--- a/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
+++ b/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Path\CurrentPathStack;
 use Drupal\group\Entity\Group;
+use Drupal\language\ConfigurableLanguageManagerInterface;
 use Drupal\language_visibility_control\LanguageVisibilityService;
 use Drupal\rest\Plugin\views\style\Serializer;
 use Drupal\rest\Plugin\views\display\RestExport;
@@ -924,19 +925,43 @@ class BebboSerializer extends Serializer {
    *   Keyed object: {machine_name: {name: "Label"}, ...}.
    */
   private function transformVocabularies(array $rows): array {
+    $langcode = $this->resolveLangcode();
+    $vocab_storage = $this->entityTypeManager->getStorage('taxonomy_vocabulary');
     $result = [];
-    foreach ($rows as $row) {
-      $parts = explode(',', $row['name'] ?? '', 2);
-      $machineName = trim($parts[0]);
-      if ($machineName === '' || $machineName === 'keywords') {
+
+    // Derive vocabularies from the view's result entities rather than the
+    // rendered "name" field. That field uses an access-gated
+    // entity_reference_label render, so anonymous API callers (the real app
+    // authenticating via JWT) would otherwise get an empty list. Loading the
+    // vocabulary and reading its label is not access-gated.
+    foreach ($this->view->result as $row) {
+      $term = $row->_entity ?? NULL;
+      if ($term === NULL) {
         continue;
       }
-      $label = htmlspecialchars_decode(
-        trim($parts[1] ?? $machineName),
-        ENT_QUOTES | ENT_HTML5,
-      );
-      $result[$machineName] = ['name' => $label];
+      $machineName = $term->bundle();
+      if ($machineName === '' || $machineName === 'keywords' || isset($result[$machineName])) {
+        continue;
+      }
+
+      // Prefer the requested language's translated vocabulary label; fall back
+      // to the base (default-language) label.
+      $label = NULL;
+      if ($this->languageManager instanceof ConfigurableLanguageManagerInterface) {
+        $label = $this->languageManager
+          ->getLanguageConfigOverride($langcode, 'taxonomy.vocabulary.' . $machineName)
+          ->get('name');
+      }
+      if (!$label) {
+        $vocab = $vocab_storage->load($machineName);
+        $label = $vocab !== NULL ? $vocab->label() : $machineName;
+      }
+
+      $result[$machineName] = [
+        'name' => htmlspecialchars_decode((string) $label, ENT_QUOTES | ENT_HTML5),
+      ];
     }
+
     return $result;
   }
 
@@ -2321,7 +2346,10 @@ class BebboSerializer extends Serializer {
   private function castToNumber(array &$row, array $fields): void {
     foreach ($fields as $field) {
       if (array_key_exists($field, $row)) {
-        $row[$field] = ($row[$field] ?? 0) + 0;
+        // Adding 0 preserves the natural int/float type, but PHP 8 throws a
+        // TypeError on non-numeric strings (e.g. an empty decimal field that
+        // Views renders as ''). Guard with is_numeric() and default to 0.
+        $row[$field] = is_numeric($row[$field]) ? $row[$field] + 0 : 0;
       }
     }
   }

--- a/docroot/modules/custom/bebbo_serializer/tests/src/Unit/CastToNumberTest.php
+++ b/docroot/modules/custom/bebbo_serializer/tests/src/Unit/CastToNumberTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\Tests\bebbo_serializer\Unit;
+
+use Drupal\bebbo_serializer\Plugin\views\style\BebboSerializer;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests numeric casting of REST row fields.
+ *
+ * Regression: empty decimal fields (average_height/average_weight) arrive as
+ * empty strings from Views, and "" + 0 throws a TypeError under PHP 8.
+ *
+ * @group bebbo_serializer
+ */
+class CastToNumberTest extends UnitTestCase {
+
+  /**
+   * Invokes the private castToNumber() on a fresh plugin instance.
+   */
+  private function castToNumber(array $row, array $fields): array {
+    $plugin = (new \ReflectionClass(BebboSerializer::class))
+      ->newInstanceWithoutConstructor();
+    $method = new \ReflectionMethod(BebboSerializer::class, 'castToNumber');
+    $method->setAccessible(TRUE);
+    $method->invokeArgs($plugin, [&$row, $fields]);
+    return $row;
+  }
+
+  /**
+   * Empty strings must not throw and must default to 0.
+   */
+  public function testEmptyStringBecomesZero(): void {
+    $row = $this->castToNumber(
+      ['average_height' => '', 'average_weight' => '1.5'],
+      ['average_height', 'average_weight']
+    );
+    $this->assertSame(0, $row['average_height']);
+    $this->assertSame(1.5, $row['average_weight']);
+  }
+
+  /**
+   * Natural int/float types are preserved (no rounding, no float coercion).
+   */
+  public function testPreservesNaturalNumericType(): void {
+    $row = $this->castToNumber(
+      ['h' => '12', 'w' => '1.50'],
+      ['h', 'w']
+    );
+    $this->assertSame(12, $row['h']);
+    $this->assertSame(1.5, $row['w']);
+  }
+
+  /**
+   * Non-numeric strings default to 0 instead of throwing.
+   */
+  public function testNonNumericBecomesZero(): void {
+    $row = $this->castToNumber(['x' => 'n/a'], ['x']);
+    $this->assertSame(0, $row['x']);
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_field/css/admin-rtl.css
+++ b/docroot/modules/custom/pb_custom_field/css/admin-rtl.css
@@ -90,4 +90,3 @@
   padding-left: 40px;
   padding-right: 7px;
 }
-

--- a/docroot/modules/custom/pb_custom_field/css/admin.css
+++ b/docroot/modules/custom/pb_custom_field/css/admin.css
@@ -85,3 +85,14 @@ table.tmgmt-ui-review input.unreviewed,
   padding: 0;
   background: transparent;
 }
+
+/* Group members operations dropbutton: Gin 5.0.x reserves only the
+   "extrasmall" toggle size (~23px) as the primary action's inline-end margin,
+   but the toggle button renders at the full --gin-spacing-xxl width (~49px)
+   and is absolutely positioned. With a long label ("Manage member") the
+   toggle overflows ~26px onto the text, drawing its divider through the label
+   while the action's own divider sits 26px further right (two lines). Reserve
+   the real toggle width so both dividers line up into one. */
+.view-group-members .dropbutton--multiple > .dropbutton__item:first-of-type {
+  margin-inline-end: calc(var(--gin-spacing-xxl) + 1px) !important;
+}

--- a/docroot/modules/custom/pb_custom_field/pb_custom_field.links.action.yml
+++ b/docroot/modules/custom/pb_custom_field/pb_custom_field.links.action.yml
@@ -1,0 +1,7 @@
+pb_custom_field.group_create_member:
+  route_name: 'entity.group_relationship.create_form'
+  route_parameters:
+    plugin_id: 'group_membership'
+  title: 'Add new member'
+  appears_on:
+    - 'view.group_members.page_1'

--- a/docroot/modules/custom/pb_custom_field/pb_custom_field.module
+++ b/docroot/modules/custom/pb_custom_field/pb_custom_field.module
@@ -26,6 +26,9 @@ use Drupal\Core\Database\Database;
 use Drupal\media\Entity\Media;
 use Drupal\file\Entity\File;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\taxonomy\TermForm;
 
 /**
@@ -1862,6 +1865,30 @@ function pb_custom_field_form_user_form_alter(&$form, FormStateInterface $form_s
  * Alters user_register_form.
  */
 function pb_custom_field_form_user_register_form_alter(&$form, &$form_state, $form_id) {
+  // --- Group membership creation wizard (port of patch #2949408) ---
+  if ($form_state->has('group') && $form_state->has('store_id')) {
+    $account = \Drupal::currentUser();
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    $group = $form_state->get('group');
+    if ($group->hasPermission('create group_membership entity', $account)) {
+      // The register form hides the password unless the creator has
+      // "administer users"; group admins need it for direct account creation.
+      $form['account']['pass'] = [
+        '#type' => 'password_confirm',
+        '#size' => 25,
+        '#description' => t('Provide a password for the new account in both fields.'),
+        '#required' => TRUE,
+      ];
+      if (isset($form['account']['notify'])) {
+        $form['account']['notify']['#access'] = TRUE;
+      }
+      // Don't let browsers prefill the group admin's own data.
+      $form['#attributes']['data-user-info-from-browser'] = FALSE;
+      // Make RegisterForm::save() treat this as an admin-created account.
+      $form['administer_users']['#value'] = TRUE;
+    }
+  }
+
   $roles = Role::loadMultiple();
   $currentUser_roles = \Drupal::currentUser()->getRoles();
   $current_path = substr(\Drupal::service('path.current')->getPath(), 1);
@@ -2459,4 +2486,65 @@ function pb_custom_field_toolbar() {
   ];
 
   return $items;
+}
+
+/**
+ * Implements hook_group_relation_type_alter().
+ *
+ * Re-enables the "create new user + add as member" wizard that the Group
+ * 1.x manage-users patch (#2949408) provided. Setting entity_access to
+ * TRUE makes Group define the create/update/delete/view
+ * "group_membership entity" permissions and exposes the
+ * /group/{group}/content/create/group_membership route.
+ */
+function pb_custom_field_group_relation_type_alter(array &$definitions): void {
+  if (isset($definitions['group_membership'])) {
+    $definitions['group_membership']->set('entity_access', TRUE);
+  }
+}
+
+/**
+ * Implements hook_menu_local_actions_alter().
+ */
+function pb_custom_field_menu_local_actions_alter(&$local_actions): void {
+  // Disambiguate from the new "Add new member" action on the members page.
+  if (isset($local_actions['group.add_member'])) {
+    $local_actions['group.add_member']['title'] = t('Add existing member');
+  }
+}
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function pb_custom_field_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL) {
+  // Let group admins set the status (active/blocked) of their members
+  // when creating or editing user accounts through the group UI.
+  if ($operation === 'edit' && $field_definition->getName() === 'status' && $items !== NULL && $items->getEntity()->getEntityTypeId() === 'user') {
+    $entity = $items->getEntity();
+    // Never open up uid 1 or the editor's own account this way.
+    if ((int) $entity->id() === 1 || (int) $entity->id() === (int) $account->id()) {
+      return AccessResult::neutral();
+    }
+    if (!$entity->isNew()) {
+      $storage = \Drupal::entityTypeManager()->getStorage('group_relationship');
+      $relationships = $storage->loadByProperties([
+        'entity_id' => $entity->id(),
+        'plugin_id' => 'group_membership',
+      ]);
+      foreach ($relationships as $relationship) {
+        /** @var \Drupal\group\Entity\GroupRelationshipInterface $relationship */
+        $group = $relationship->getGroup();
+        if ($group->hasPermission('update any group_membership entity', $account)) {
+          return AccessResult::allowed()
+            ->addCacheableDependency($relationship)
+            ->cachePerUser();
+        }
+      }
+    }
+    elseif (($group = \Drupal::routeMatch()->getParameter('group')) && $group instanceof GroupInterface) {
+      return AccessResult::allowedIf($group->hasPermission('create group_membership entity', $account))
+        ->addCacheContexts(['route', 'user']);
+    }
+  }
+  return AccessResult::neutral();
 }

--- a/docroot/modules/custom/pb_custom_field/pb_custom_field.services.yml
+++ b/docroot/modules/custom/pb_custom_field/pb_custom_field.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\pb_custom_field\Routing\AdminRouteSubscriber
     tags:
       - { name: event_subscriber }
+  pb_custom_field.group_create_form_route_subscriber:
+    class: Drupal\pb_custom_field\Routing\GroupCreateFormRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/pb_custom_field/src/Controller/GroupMembershipCreateController.php
+++ b/docroot/modules/custom/pb_custom_field/src/Controller/GroupMembershipCreateController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\pb_custom_field\Controller;
+
+use Drupal\group\Entity\Controller\GroupRelationshipController;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\Storage\GroupRelationshipTypeStorageInterface;
+
+/**
+ * Creates group membership for a NEW user account via the creation wizard.
+ *
+ * Identical to the parent controller except that wizard step 1 for the
+ * group_membership plugin uses the user entity's "register" form operation
+ * (ports the Group 1.x manage-users patch, issue #2949408).
+ */
+class GroupMembershipCreateController extends GroupRelationshipController {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createForm(GroupInterface $group, $plugin_id) {
+    if ($plugin_id !== 'group_membership') {
+      return parent::createForm($group, $plugin_id);
+    }
+
+    $wizard_id = 'group_entity';
+    $store = $this->privateTempStoreFactory->get($wizard_id);
+    $store_id = $plugin_id . ':' . $group->id();
+
+    $group_relation = $group->getGroupType()->getPlugin($plugin_id);
+    $config = $group_relation->getConfiguration();
+    $extra['group_wizard'] = $config['use_creation_wizard'];
+    $extra['group_wizard_id'] = $wizard_id;
+    $extra['group'] = $group;
+    $extra['group_relation'] = $plugin_id;
+    $extra['store_id'] = $store_id;
+
+    $step2 = $extra['group_wizard'] && $store->get("$store_id:step") === 2;
+
+    if (!$step2) {
+      // Wizard step 1: the user REGISTER form (not the default profile form).
+      $storage = $this->entityTypeManager()->getStorage('user');
+      if (!$entity = $store->get("$store_id:entity")) {
+        $entity = $storage->create([]);
+      }
+      $operation = 'register';
+    }
+    else {
+      // Wizard step 2: the relationship add form (same as parent).
+      $relationship_type_storage = $this->entityTypeManager()->getStorage('group_relationship_type');
+      assert($relationship_type_storage instanceof GroupRelationshipTypeStorageInterface);
+      $entity = $this->entityTypeManager()->getStorage('group_relationship')->create([
+        'type' => $relationship_type_storage->getRelationshipTypeId($group->bundle(), $plugin_id),
+        'gid' => $group->id(),
+      ]);
+      $operation = 'add';
+    }
+
+    return $this->entityFormBuilder()->getForm($entity, $operation, $extra);
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_field/src/PbCustomFieldServiceProvider.php
+++ b/docroot/modules/custom/pb_custom_field/src/PbCustomFieldServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\pb_custom_field;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\pb_custom_field\Plugin\Group\RelationHandler\BebboMembershipAccessControl;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Swaps the membership access-control relation handler.
+ */
+class PbCustomFieldServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    if ($container->hasDefinition('group.relation_handler.access_control.group_membership')) {
+      $definition = $container->getDefinition('group.relation_handler.access_control.group_membership');
+      // Wrap Group's handler: our class decorates the original class, which
+      // itself decorates the default handler.
+      $container->register('pb_custom_field.membership_access_inner', $definition->getClass())
+        ->setArguments($definition->getArguments())
+        ->setShared(FALSE);
+      $definition->setClass(BebboMembershipAccessControl::class)
+        ->setArguments([new Reference('pb_custom_field.membership_access_inner')]);
+    }
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_field/src/Plugin/Group/RelationHandler/BebboMembershipAccessControl.php
+++ b/docroot/modules/custom/pb_custom_field/src/Plugin/Group/RelationHandler/BebboMembershipAccessControl.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\pb_custom_field\Plugin\Group\RelationHandler;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Plugin\Group\RelationHandler\AccessControlInterface;
+use Drupal\group\Plugin\Group\RelationHandler\AccessControlTrait;
+
+/**
+ * Membership access control with uid-1 and self guards.
+ *
+ * Decorates Group's GroupMembershipAccessControl; group-level permissions
+ * must never grant a group admin access to uid 1 or to their own account
+ * (port of GroupMembershipContentAccessControlHandler, patch #2949408).
+ */
+class BebboMembershipAccessControl implements AccessControlInterface {
+
+  use AccessControlTrait;
+
+  /**
+   * Constructs a new BebboMembershipAccessControl.
+   *
+   * @param \Drupal\group\Plugin\Group\RelationHandler\AccessControlInterface $parent
+   *   The parent access control handler.
+   */
+  public function __construct(AccessControlInterface $parent) {
+    $this->parent = $parent;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityAccess(EntityInterface $entity, $operation, AccountInterface $account, $return_as_object = FALSE) {
+    if ((int) $entity->id() === 1 || (int) $entity->id() === (int) $account->id()) {
+      $result = AccessResult::neutral();
+      return $return_as_object ? $result : FALSE;
+    }
+    return $this->parent->entityAccess($entity, $operation, $account, $return_as_object);
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_field/src/Routing/GroupCreateFormRouteSubscriber.php
+++ b/docroot/modules/custom/pb_custom_field/src/Routing/GroupCreateFormRouteSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\pb_custom_field\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Swaps the relationship create-form controller for the membership wizard.
+ */
+class GroupCreateFormRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    if ($route = $collection->get('entity.group_relationship.create_form')) {
+      $route->setDefault('_controller', '\Drupal\pb_custom_field\Controller\GroupMembershipCreateController::createForm');
+    }
+  }
+
+}

--- a/docroot/modules/custom/pb_custom_field/tests/src/Kernel/MembershipEntityAccessTest.php
+++ b/docroot/modules/custom/pb_custom_field/tests/src/Kernel/MembershipEntityAccessTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Tests\pb_custom_field\Kernel;
+
+use Drupal\Tests\group\Kernel\GroupKernelTestBase;
+
+/**
+ * Tests the uid-1/self guards on membership entity access.
+ *
+ * @group pb_custom_field
+ */
+class MembershipEntityAccessTest extends GroupKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['pb_custom_field'];
+
+  /**
+   * Group admins must never gain via-group access to uid 1 or themselves.
+   */
+  public function testUidOneAndSelfAreGuarded(): void {
+    $admin = $this->createUser();
+    $group_type = $this->createGroupType();
+    // Grant the entity permissions our relation-type alter hook enables.
+    $role = $this->createGroupRole([
+      'group_type' => $group_type->id(),
+      'scope' => 'individual',
+      'permissions' => [
+        'update any group_membership entity',
+        'view group_membership entity',
+      ],
+    ]);
+
+    $group = $this->createGroup(['type' => $group_type->id()]);
+    $group->addMember($admin, ['group_roles' => [$role->id()]]);
+
+    $member = $this->createUser();
+    $group->addMember($member);
+
+    $uid1 = $this->container->get('entity_type.manager')->getStorage('user')->load(1);
+    $group->addMember($uid1);
+
+    $access_control = $this->pluginManager->getAccessControlHandler('group_membership');
+
+    // Regular member: group admin may update.
+    $this->assertTrue($access_control->entityAccess($member, 'update', $admin));
+    // Uid 1: never via group permissions.
+    $this->assertFalse($access_control->entityAccess($uid1, 'update', $admin));
+    // Self: never via group permissions.
+    $this->assertFalse($access_control->entityAccess($admin, 'update', $admin));
+  }
+
+}


### PR DESCRIPTION
## Summary

### Group 3.x "manage users" flow (zero-patch, in pb_custom_field)

- `hook_group_relation_type_alter()` enables `entity_access` on `group_membership`, generating the create/update/view permissions and the create route
- Route subscriber + `GroupMembershipCreateController` render the user register form as wizard step 1 (keeps form id `user_register_form` so existing glue works); register-form alter adds password/notify/status handling
- `BebboMembershipAccessControl` (via `PbCustomFieldServiceProvider`) adds uid-1 and self guards on membership entity access (kernel-tested)
- `entity_field_access` opens the user status field to group admins
- "Add new member" local action + "Add existing member" retitle
- `group_members` view: enable the existing "Remove member" dropbutton action (removes membership only); the patch's Delete-User link is not used

### bebbo_serializer API fixes

- `castToNumber()`: guard against non-numeric strings; `"" + 0` threw a PHP 8 TypeError and crashed the weekly-overview endpoint (unit test added)
- Vocabularies endpoint: build names from the view result entities instead of the access-gated `entity_reference_label` render, so anonymous/JWT callers get data instead of an empty list

### Quiz content type

- Restore lowercase JS boolean literals (a prior phpcbf run uppercased `false/true/null`, which is invalid JS and crashed the script)
- Show the "Add quiz question" button for a single-question quiz with zero questions so the one required question can be added

### Other

- Weekly-overview: drop a bogus `{{ ...|number_format }}` rewrite on an image field that emitted a Markup-to-float warning on every render
- Dropbutton: align the members Operations toggle so the label/arrow no longer overlap the divider (Gin 5.0.x toggle-size mismatch)
- Bump phpunit to `^11.5` (9.6 cannot bootstrap D11.3 kernel tests); remove `drupal/variationcache` (now in core)