### PR TITLE
docs: update documentation for MFA, email migration, and recent fixes

### DIFF
--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -4,14 +4,14 @@ langcode: en
 anonymous: Anonymous
 verify_mail: true
 notify:
-  cancel_confirm: true
+  cancel_confirm: false
   password_reset: true
-  status_activated: true
+  status_activated: false
   status_blocked: false
   status_canceled: false
   register_admin_created: true
-  register_no_approval_required: true
-  register_pending_approval: true
+  register_no_approval_required: false
+  register_pending_approval: false
 register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,7 +12,7 @@
 |---------|------|-----------|--------|
 | **V1 REST** | `/api/*` | `custom_serialization` Views style (+ `bebbo_serializer` for `/api/strings`, `pb_custom_standard_deviation` for `/api/standard_deviation`) | Legacy — still live |
 | **V2 REST** | `/v2/api/*` | `bebbo_serializer` Views style | Current |
-| **Force-Update** | `/api/check-update/{country}` | `pb_custom_rest_api` REST resource (`custom_rest_resource`) | Live |
+| **Force-Update** | `/api/check-update/{country}` + `/v2/api/check-update/{country}` | `pb_custom_rest_api` REST resources (`custom_rest_resource` / `v2_custom_rest_resource`) | Live |
 | **Device Security** | `/api/security/*` | `bebbo_api_security` (`SecurityController`) | Live — attestation + JWT issuance (see [§13.1](#131-device-security--attestation-api-apisecurity)) |
 | **App-links** | `/.well-known/*` | `mobile_app_links` (`WellKnownController`) | Live — deep-link domain verification (see [§13.2](#132-app-link-well-known-endpoints)) |
 | **JSON:API** | `/jsonapi/*` | core `jsonapi` + `jsonapi_extras` | Enabled, **read-only** |
@@ -70,10 +70,11 @@ Only those two flags. **No pretty-print, and no `&nbsp;` substitution** — earl
 | Type casting | inline `(int)`, comma-split | helper methods `castToInt/castToBool/castToNumber/toIntArray/toStringArray` |
 | New content types | — | **Course** (`/v2/api/course`), **Quiz** (`/v2/api/quiz`) |
 | New endpoints | — | **`/v2/api/guide`**, **`/v2/api/weekly-overview`** |
-| Dropped in V2 | `sponsors`, `strings`*, `related-article-contents/*/milestone`, `updated-pinned-contents/*/faq`, the `pinned-contents/*/faq|child_growth|health_check_ups|vaccinations` variants | (not re-implemented) |
+| Dropped in V2 | `sponsors`, `related-article-contents/*/milestone`, `updated-pinned-contents/*/faq`, the `pinned-contents/*/faq|child_growth|health_check_ups|vaccinations` variants | (not re-implemented) |
+| New V2 aliases | — | `/v2/api/strings/%` (same as V1 `/api/strings/%`) and `/v2/api/check-update/{country}` (same as V1 `/api/check-update/{country}`) — identical responses at V2 URL paths |
 | Engagement counts | — | `read_count`, `love_count` on activities/articles/video-articles/course |
 
-\* `/api/strings/%` is actually served by the **`bebbo_serializer`** style (not `custom_serialization`), even though it sits under `/api/`. There is no `/v2/api/strings`.
+\* `/api/strings/%` is served by the **`bebbo_serializer`** style (not `custom_serialization`), even though it sits under `/api/`. A V2 alias at `/v2/api/strings/%` now exists as well (same view, `v2_string_rest_export` display).
 
 > Both V1 and V2 remain live. The mobile app migrated to V2; V1 is retained for backward compatibility.
 
@@ -112,7 +113,7 @@ Only those two flags. **No pretty-print, and no `&nbsp;` substitution** — earl
 | `/api/country-groups/%` | country_listing / custom_serialization | langcode forced to `en` |
 | `/api/vocabularies/%` | tax / custom_serialization | keyed map (see [§7](#7-taxonomy--vocabulary)) |
 | `/api/taxonomies/%/%` | tax / custom_serialization | keyed map |
-| `/api/strings/%` | tax / **`bebbo_serializer`** | **V1-only** |
+| `/api/strings/%` | tax / **`bebbo_serializer`** | Also available at `/v2/api/strings/%` (same view, `v2_string_rest_export` display) |
 | `/api/sponsors/%` | sponsors_list / custom_serialization | **V1-only**; `%` is country-group id (`all` allowed), no `langcode` key in output |
 
 ### 4.2 Shared value transforms (`CustomSerializer::render`)
@@ -164,6 +165,8 @@ V1 honors exactly **one** parameter inside the serializer: **`pregnancy=true`** 
 | `/v2/api/country-groups/%` | `country_listing_export` (country_listing view) | `transformCountryGroups` |
 | `/v2/api/vocabularies/%` | `vocabulary_rest_export` (tax view) | `transformVocabularies` |
 | `/v2/api/taxonomies/%/%` | `terms_rest_export` (tax view) | `transformTaxonomies` |
+| `/v2/api/strings/%` | `v2_string_rest_export` (tax view) | Same fields/filters as V1 `/api/strings/%` — V2 URL alias |
+| `/v2/api/check-update/{country}` | `v2_custom_rest_resource` (REST plugin) | Same as V1 `/api/check-update/{country}` — V2 URL alias |
 
 ### 5.1 Envelope variants
 - **Standard:** `{status,total,langcode,datetime,data}`; `total = (int) view->total_rows`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,19 +62,17 @@ flowchart TB
         ai[OpenAI<br/>AI translation]
         bq[BigQuery HTTP API<br/>content analytics]
         attest[Apple App Attest /<br/>Google Play Integrity]
-        ga[Google Analytics]
-        smtp[SMTP mail]
+        mailer[Office 365 OAuth mail<br/>Symfony Mailer]
     end
 
     cms --> tmgmt
     cms --> ai
     cms --> bq
     sec --> attest
-    cms --> ga
-    cms --> smtp
+    cms --> mailer
 ```
 
-External integrations are enabled in `composer.json` and described in detail in **`DEPENDENCIES.md`** (to be created). API security details live in **`API_SECURITY.md`**; the REST surface in **`API_REFERENCE.md`**.
+External integrations are enabled in `composer.json` and described in detail in **`DEPENDENCIES.md`**. API security details live in **`API_SECURITY.md`**; the REST surface in **`API_REFERENCE.md`**.
 
 > **No GraphQL.** The project exposes **REST** (custom serializers — V1 under `/api/…`, V2 under `/v2/api/…`) and **JSON:API** (`jsonapi` + `jsonapi_extras`, both enabled). There is no GraphQL module in `composer.json`, `composer.lock`, or `docroot/modules/contrib`. The V2 API is protected by the `bebbo_api_security` JWT layer (see `API_SECURITY.md`).
 >
@@ -184,7 +182,7 @@ flowchart TB
 
 ### 4.1 Module installation rule (critical)
 
-`core.extension.yml` lives **only** in `config/sync` and is the single source of truth for enabled modules across all 7 sites (**167 modules + 2 themes enabled** at `HEAD`). A site needing an extra module declares it in the `module:` field of its split entity — **never** by adding `core.extension` to a split. Details and the editing workflow are in **`CONFIGURATION.md`**.
+`core.extension.yml` lives **only** in `config/sync` and is the single source of truth for enabled modules across all 7 sites (**171 modules + 2 themes enabled** at `HEAD`). A site needing an extra module declares it in the `module:` field of its split entity — **never** by adding `core.extension` to a split. Details and the editing workflow are in **`CONFIGURATION.md`**.
 
 ---
 

--- a/docs/CICD_DEPLOYMENT.md
+++ b/docs/CICD_DEPLOYMENT.md
@@ -97,7 +97,7 @@ Run on Acquia infrastructure after code lands on an environment (not in GitHub A
 ### `code-deploy.sh` behaviour
 Args (Acquia-supplied): `site target-env source-branch deployed-tag repo-url repo-type`. `set -e` (exit on error).
 
-- **If `target_env != prod`:** `cd /var/www/html/$site.$target_env`, source `sites.sh`, then for **each** of the 7 sites run (with progress `Site N/7: name`), using `php -d memory_limit=1024M vendor/bin/drush @$site.$target_env -l $site_name`:
+- **If `target_env != prod`:** `cd /var/www/html/$site.$target_env`, source `sites.sh`, then for **each** of the 7 sites run (with progress `Site N/7: name`), using `php -d memory_limit=1024M vendor/drush/drush/drush.php @$site.$target_env -l $site_name`:
   1. `drush cr` — cache rebuild
   2. `drush updb -y` — database updates
   3. `drush cim -y` — config import (pass 1)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -160,7 +160,21 @@ After standard login, users are redirected to the OTP verification page. On succ
 | Cancel method | `user_cancel_block` |
 | Password reset timeout | `86400` s (24 h) |
 | Password strength meter | `true` |
-| Notify on reset / activate / admin-created | all `true` |
+
+**User email notifications** — restricted to security-related and onboarding emails only:
+
+| Notification | Enabled | Reason |
+|---|---|---|
+| `password_reset` | **true** | Security — user-initiated password recovery |
+| `register_admin_created` | **true** | Onboarding — one-time login link for new users (registration is `admin_only`) |
+| `cancel_confirm` | false | Non-essential |
+| `status_activated` | false | Non-essential |
+| `status_blocked` | false | Non-essential |
+| `status_canceled` | false | Non-essential |
+| `register_no_approval_required` | false | Not applicable (`admin_only` registration) |
+| `register_pending_approval` | false | Not applicable (`admin_only` registration) |
+
+Combined with Email TFA (§1 above) and disabled content moderation notifications (§7), the only emails users receive are: **MFA OTP codes**, **password reset links**, and **admin-created account links**.
 
 ### Keys — `key.key.*`
 | Key ID | Label | Provider | Source |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,11 +52,41 @@ Complete reference of the configuration stored in this Drupal 11 multisite, sour
 | `syslog.settings` | Identity / Facility | `bebbo` / `128` (LOG_LOCAL0) |
 | `syslog.settings` | Format | `!base_url\|!timestamp\|!type\|!ip\|!request_uri\|!referer\|!uid\|!link\|!message` |
 
-### Mail — `system.mail.yml`
+### Mail — `system.mail.yml` + Symfony Mailer
+
 | Setting | Value |
 |---|---|
-| Default interface | `SMTPMailSystem` |
+| Default interface | `php_mail` (Symfony Mailer takes over at the transport layer) |
 | Mailer DSN | scheme `sendmail`, host `default` |
+| Default transport | `office_365_oauth` (`symfony_mailer.settings.yml`) |
+| Transport host | `smtp.office365.com:587` (TLS) |
+| Transport user | `admin@bebbo.app` |
+| Transport auth plugin | `office365_oauth` (`symfony_mailer_office365`) |
+| OAuth credentials | Placeholders in config — real values entered per-environment via `/admin/config/system/mailer/office365`; protected by `config_ignore` |
+| Mailer policy | URL-to-absolute, inline CSS, wrap-and-convert (plain: false, swiftmailer: false), theme: `_active_fallback` |
+| Test email policy | Subject `"Test email from [site:name]"`, format `email_html` |
+
+**Background:** `drupal/smtp` (Basic Auth via `SMTPMailSystem`) was removed because Microsoft 365 Security Defaults block Authenticated SMTP at the tenant level. Replaced by `drupal/symfony_mailer` + `drupal/symfony_mailer_office365` using OAuth 2.0 Authorization Code flow (delegated `SMTP.Send` permission). OAuth tokens are auto-refreshed via Drupal cron. See [`RUNBOOK.md`](RUNBOOK.md) §14 for post-deployment setup steps.
+
+### Email TFA (Multi-Factor Authentication) — `email_tfa.settings.yml`
+
+| Setting | Value |
+|---|---|
+| Status | `enabled` (`status: true`) |
+| Scope | `globally_enabled` (all users) |
+| OTP code length | `6` digits |
+| OTP timeout | `300` s (5 min) |
+| Flood protection | `5` attempts per `3600` s (1 h) |
+| Dev mode | `disabled` |
+| Role exclusion | none (`ignore_role: {}`) |
+| Email subject | "One Time Password" |
+| Email body tokens | `[user:email_tfa]`, `[user:name]`, `[site:name]` |
+| Log events | `disabled` |
+| Routes intercepted | `email_tfa.verifiy`, `user.logout` |
+| Admin settings | `/admin/config/people/email-tfa` (permission: `administer email tfa`) |
+| Verification route | `/tfa/verify/{uid}/{hash}` |
+
+After standard login, users are redirected to the OTP verification page. On successful verification, users are redirected to `/dashboard` (via custom submit handler in `pb_custom_field`). Bebbo split carries language translation overrides for `email_tfa.settings` in `ro`, `ru`, `sk`, `sq`, `sr`, `uk`.
 
 ### Admin UI
 | File | Setting | Value |
@@ -89,6 +119,7 @@ Complete reference of the configuration stored in this Drupal 11 multisite, sour
 | `admin_full_html` | Admin Full HTML | Active |
 | `full_html` | Full HTML | Active (weight -10) |
 | `plain_text` | Plain text | Active (weight -8) |
+| `email_html` | Email HTML | Active (weight 10) — used by Symfony Mailer test email templates; no filters configured |
 | `basic_html` | Basic HTML | **Disabled** |
 | `restricted_html` | Restricted HTML | **Disabled** |
 
@@ -680,12 +711,12 @@ Default moderation state: **draft**.
 ### Moderation notifications (`content_moderation_notifications.*` — 7)
 | ID | Trigger | Notifies | Status |
 |---|---|---|---|
-| `draft_to_sme` | Draft → SME Review | SME | Active |
-| `draft_to_sr_editor` | Draft → Sr. Editor Review | Senior Editor | Active |
-| `sme_review_to_sr_editor_review_` | SME Review → Sr. Editor Review | Senior Editor | Active |
-| `sme_to_require_modification` | SME Review → Require Modification | Editor | Active |
-| `sr_editor_review_to_require_modifications_` | Sr. Editor Review → Require Modifications | Editor | Active |
-| `master_any_state_to_review_after_translation` | Any → Review after translation | Editor, SE | Active |
+| `draft_to_sme` | Draft → SME Review | SME | **Disabled** |
+| `draft_to_sr_editor` | Draft → Sr. Editor Review | Senior Editor | **Disabled** |
+| `sme_review_to_sr_editor_review_` | SME Review → Sr. Editor Review | Senior Editor | **Disabled** |
+| `sme_to_require_modification` | SME Review → Require Modification | Editor | **Disabled** |
+| `sr_editor_review_to_require_modifications_` | Sr. Editor Review → Require Modifications | Editor | **Disabled** |
+| `master_any_state_to_review_after_translation` | Any → Review after translation | Editor, SE | **Disabled** |
 | `master_senior_editor_publish` | Sr. Editor / Draft → Published | Editor, SE | **Disabled** |
 
 All notify the role only (author + site_mail notifications off).
@@ -851,14 +882,31 @@ The path/count/disable settings actually live in **`jsonapi_extras.settings.yml`
 | Default disabled | `false` | jsonapi_extras.settings |
 | Validate config integrity | `false` | jsonapi_extras.settings |
 
-### REST resource — `rest.resource.custom_rest_resource`
+### REST resources
+
+**`rest.resource.custom_rest_resource`** — V1 force-update check
+
 | Setting | Value |
 |---|---|
 | Plugin | `custom_rest_resource` (from `pb_custom_rest_api`) |
+| Path | `/api/check-update/{country}` |
 | Methods | GET |
 | Formats | json |
 | Authentication | basic_auth |
 | Granularity | resource |
+
+**`rest.resource.v2_custom_rest_resource`** — V2 force-update check
+
+| Setting | Value |
+|---|---|
+| Plugin | `v2_custom_rest_resource` (from `pb_custom_rest_api`) |
+| Path | `/v2/api/check-update/{country}` |
+| Methods | GET |
+| Formats | json |
+| Authentication | basic_auth |
+| Granularity | resource |
+
+The V2 resource extends the V1 class with zero logic changes — identical response, different URL path.
 
 ---
 
@@ -999,13 +1047,12 @@ Country coverage (approx counts): Albania 45, Serbia 36, Greece 27 (3 languages:
 - **All sites:** block, language entities, mobile_app_links, pb_custom_form, system.site
 - **entity_share_client:** all except bebbo (bangla, ecuador, pakistan, somoa, turkey, zimbabwe)
 - **ai_translate:** all 6 non-default sites
-- **SMTP:** ecuador, turkey
 - **Field overrides:** bangla, pakistan, somoa, turkey
 - **entity_share_server channels (~30):** somoa, zimbabwe (+ turkey, ecuador)
 - **workflows.workflow.group_workflow:** somoa, turkey, zimbabwe (complete_list)
 
 ### `config_ignore.settings.yml` — never imported/exported
-`admin_toolbar.settings`, `bebbo_api_security.settings`, `entity_share_client.remote*`, `google_analytics.settings`, `mobile_app_links.android_packages`, `mobile_app_links.ios`, `pb_content_analytics.settings`, `pb_custom_form.landing_pages`, `pb_custom_form.language_redirects`, `pb_custom_form.mobile_app_share_link_form`, `purge.logger_channels`, `smtp.settings`, `tmgmt.translator.*`, `tmgmt_memsource.settings`, `views.view.entity_share_client_entity_import_status`.
+`admin_toolbar.settings`, `bebbo_api_security.settings`, `entity_share_client.remote*`, `mobile_app_links.android_packages`, `mobile_app_links.ios`, `pb_content_analytics.settings`, `pb_custom_form.landing_pages`, `pb_custom_form.language_redirects`, `pb_custom_form.mobile_app_share_link_form`, `purge.logger_channels`, `symfony_mailer.mailer_transport.office_365_oauth`, `symfony_mailer_office365.config`, `tmgmt.translator.*`, `tmgmt_memsource.settings`, `views.view.entity_share_client_entity_import_status`.
 
 ### Custom-module configs in sync
 - `pb_custom_form.adminsettings` — Master language `en,sr,ru,sq`

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -193,6 +193,7 @@ Grouped by function for readability. **Constraint** is the exact string from `co
 | `drupal/contextual_range_filter` | `^3.0` |
 | `drupal/better_exposed_filters` | `^7.1` |
 | `drupal/content_moderation_notifications` | `^3.7` |
+| `drupal/contextual_range_filter` | `^3.0` |
 | `drupal/rdf` | `^3.0@beta` |
 | `drupal/quickedit` | `^2.0` |
 | `drupal/layout_builder_styles` | `^2.1` |
@@ -231,7 +232,6 @@ Grouped by function for readability. **Constraint** is the exact string from `co
 | `drupal/toolbar_menu_clean` | `^2.0` |
 | `drupal/fpa` | `^4.0` |
 | `drupal/devel` | `^5.4` |
-| `drupal/upgrade_status` | `^4.3` |
 | `drupal/drupal-extension` | `dev-main` (Behat; declared in `require`, not `require-dev`) |
 
 ### 3.14 Security & auth primitives
@@ -242,18 +242,31 @@ Grouped by function for readability. **Constraint** is the exact string from `co
 | `drupal/security_review` | `^3.1` | Security audit checklist |
 | `drupal/shield` | `^1.2.0` | HTTP basic-auth shield |
 | `drupal/key` | `^1.22` | Key/secret management |
+| `drupal/email_tfa` | `^3.0` | Email-based two-factor authentication (MFA) — OTP sent to user's email after login |
 | `enshrined/svg-sanitize` | `^0.22.0` | SVG sanitization (used by `file_sanitizer`) |
 | `firebase/php-jwt` | `^7.0@stable` | JWT sign/verify (V2 API security) |
 | `spomky-labs/cbor-php` | `^3.0` | CBOR decode (Apple App Attest) |
 
-### 3.15 Mail & analytics
+### 3.15 Mail & mobile
 
 | Package | Constraint | Role |
 |---------|-----------|------|
-| `drupal/symfony_mailer` | `^1.4` | Mailer |
-| `drupal/smtp` | `^1.0` | SMTP transport |
-| `drupal/google_analytics` | `^4.0` | GA tracking |
+| `drupal/symfony_mailer` | `^1.4` | Symfony Mailer framework (mail transport layer) |
+| `drupal/symfony_mailer_office365` | `^1.0@alpha` | Office 365 OAuth (XOAUTH2) transport for Symfony Mailer |
 | `drupal/mobile_app_links` | `^2.0` | `.well-known` deep-link files |
+
+### 3.16 Database compatibility
+
+| Package | Constraint | Role |
+|---------|-----------|------|
+| `drupal/mysql57` | `^1.0` | MySQL 5.7 backport driver for Acquia Dev (Drupal 11 requires MySQL 8.0+) |
+
+### 3.17 Frontend assets
+
+| Package | Constraint | Role |
+|---------|-----------|------|
+| `npm-asset/js-cookie` | `^3.0` | js-cookie library (installed locally, avoids CDN loading) |
+| `oomphinc/composer-installers-extender` | `^2.0` | Allows Composer to install npm-asset packages to `docroot/libraries/` |
 
 ---
 
@@ -344,6 +357,7 @@ Applied by `cweagans/composer-patches`. `composer-exit-on-patch-failure: true` �
 | `drupal/config_split` | Collection `complete_list` matching on export (lang overrides → wrong dir) | local |
 | `drupal/inline_entity_form` | Allow override of translation restriction on IEF add-new | local |
 | `drupal/autocomplete_id` | Filter unpublished entities from ID autocomplete | local |
+| `drupal/contextual_range_filter` | PHP 8.4 implicit-nullable in `DateRange::init()` (3521312) | local |
 | `drupal/menu_export` | Drush command calling protected `exportMenus` | local |
 
 ---
@@ -367,10 +381,9 @@ What the codebase reaches out to over the network, and which dependency drives i
 | Microsoft Translator | `tmgmt_microsoft` | Translation API | Backend for TMGMT |
 | Phrase / Memsource | `tmgmt_memsource` | Translation API | Backend for TMGMT |
 | OpenAI | `ai` + `ai_provider_openai` | AI API | AI-assisted translation/content |
-| Google Analytics | `google_analytics` | Analytics | Editorial/admin tracking |
 | BigQuery | **custom** `pb_content_analytics` | HTTP analytics | No contrib package — custom HTTP sync (see `MODULES.md`) |
 | Apple App Attest / Google Play Integrity | **custom** `bebbo_api_security` | Device attestation | Uses `firebase/php-jwt` + `spomky-labs/cbor-php` + OpenSSL; not a contrib integration package (see `API_SECURITY.md`) |
-| SMTP mail server | `symfony_mailer` + `smtp` | Mail | Outbound editorial mail |
+| Microsoft 365 (Office 365 OAuth mail) | `symfony_mailer` + `symfony_mailer_office365` | Mail | OAuth 2.0 (Authorization Code) via `smtp.office365.com:587`; sends as `admin@bebbo.app`. Replaced `drupal/smtp` (Basic Auth blocked by M365 Security Defaults). OAuth credentials managed per-environment via `config_ignore`. See [`CONFIGURATION.md`](CONFIGURATION.md) §1 and [`RUNBOOK.md`](RUNBOOK.md) §14 |
 | Acquia Cloud (Varnish/CDN, memcache) | `acquia_connector` · `acquia_purge` · `memcache` · `acquia/memcache-settings` | Hosting/cache | Production platform |
 
 ---

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -12,6 +12,8 @@
 |-------------|-------|-----|----------------|---------------|---------------|
 | **Local** | DDEV (`bebbo.app`) | 8.4 | n/a (manual `ddev start`) | — | `config/sync` + active split |
 | **Dev** | Acquia Cloud | **8.4** | push to `develop` | `@parentbuddy2.dev` | `config/sync` + active split |
+
+> Acquia Dev runs MySQL 5.7.44 — below Drupal 11's MySQL 8.0 minimum. The `drupal/mysql57` contrib module backports the database driver. Its settings include is loaded in `post.settings.php` after the Acquia include so `$databases` is already populated.
 | **Stage** | Acquia Cloud | **8.4** | push to `stage` | `@parentbuddy2.test` | `config/sync` + active split |
 | **Prod** | Acquia Cloud | **8.4**¹ | **manual only** | `@parentbuddy2.prod`¹ | `config/sync` + active split |
 
@@ -108,10 +110,10 @@ include site.splits.php;                              // activate split
 ### 4.3 What each shared file actually sets (verified)
 
 - **`common.settings.php`** — is essentially stock Drupal `default.settings.php`. It does **not** set production `trusted_host_patterns`, real `hash_salt`, or `config_sync_directory` (those are commented stock docs). It *does* set: `update_free_access = FALSE`, `file_scan_ignore_directories`, `entity_update_batch_size = 50`, `entity_update_backup = TRUE`, `state_cache = TRUE`, container services yaml.
+- **`docroot/sites/default/services.yml`** — sets `session.cookie_samesite: Lax` (security hardening).
 - **`post.settings.php`** — the real environment logic:
   - `config_sync_directory = '../config/sync'` (always).
   - `hash_salt = hash('sha256', $app_root . '/' . $site_path)` (always).
-  - SMTP user/pass read from env vars (`getenv(...) ?: ''`).
   - tmgmt translator API keys are present but **commented out**.
 
 > **Trusted hosts:** in-repo, `trusted_host_patterns` is set only in **DDEV** (`['.*']`). Production host validation is handled by the Acquia per-site include (`/var/www/site-php/{group}/{file}.inc`) which lives **on Acquia's servers, not in this repo** — so it is not documented here.
@@ -198,7 +200,7 @@ Exactly the 7 active sites (no `pacific_islands`).
 - For non-prod, loops every site in `SITES` with labeled progress (`Site N/7: name`, steps `[1/5]`–`[5/5]`), and runs per site:
 
 ```bash
-DRUSH="php -d memory_limit=1024M vendor/bin/drush @$site.$target_env -l $site_name"
+DRUSH="php -d memory_limit=1024M vendor/drush/drush/drush.php @$site.$target_env -l $site_name"
 $DRUSH cr              # [1/5] cache rebuild
 $DRUSH updb -y         # [2/5] database updates
 $DRUSH cim -y          # [3/5] config import (pass 1)
@@ -218,7 +220,21 @@ Entity Share exposes per-site channels and pulls content over JSON:API from a re
 
 ---
 
-## 10. Related Docs
+## 10. Post-Deployment: Email OAuth Setup
+
+Email delivery via Symfony Mailer + Office 365 OAuth requires per-environment configuration after deploy. OAuth credentials are managed via the admin UI and protected by `config_ignore` — they are **not** in Git.
+
+After deploying to a new environment:
+1. Microsoft Entra app registration (client's M365 admin)
+2. Drupal credential entry at `/admin/config/system/mailer/office365`
+3. Interactive OAuth authorization in browser
+4. Verification: test email on all 7 sites
+
+Full step-by-step procedure: [`RUNBOOK.md`](RUNBOOK.md) §12.
+
+---
+
+## 11. Related Docs
 
 | Topic | Doc |
 |-------|-----|

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -218,6 +218,8 @@ The largest editorial module. Controls field access, form alterations, editorial
 | `hook_menu_local_actions_alter` | Renames "Add member" → "Add existing member" |
 | `hook_entity_operation_alter` | Controls edit/delete/translate by moderation state |
 | `hook_entity_field_access` | Lets group admins set user status via group UI |
+| `hook_user_login_form_submit` | Dashboard redirect after login — early-returns if user is anonymous (guards against redirect before TFA verification) |
+| `hook_form_email_tfa_email_tfa_verify_login_alter` | Adds dashboard redirect submit handler to TFA OTP verification form, so user lands on `/dashboard` after successful MFA |
 | `hook_form_user_login_form_alter` | Adds password reset link |
 | `hook_form_user_form_alter` | Customizes user profile form |
 | `hook_form_user_register_form_alter` | Group membership creation wizard, restricts role selection |
@@ -593,7 +595,9 @@ Sanitizes filenames on upload (transliteration, unsafe character removal, lowerc
 
 Single REST resource plugin for the force-update check endpoint.
 
-### REST Resource
+### REST Resources
+
+**V1 — `CustomRestResource`**
 
 | Property | Value | Source |
 |----------|-------|--------|
@@ -605,6 +609,17 @@ Single REST resource plugin for the force-update check endpoint.
 The plugin annotation declares only `id`, `label`, and `uri_paths`. Enabled methods, formats, and authentication are defined in the REST resource config (`rest.resource.custom_rest_resource.yml`), which lives in shared base config (`config/sync/`), not in this module.
 
 `CustomRestResource::get($country)` queries the `forcefull_check_update_api` table (owned by `pb_custom_form`) for the latest `content_update` and `app_update` records by country group ID.
+
+**V2 — `V2CustomRestResource`**
+
+| Property | Value | Source |
+|----------|-------|--------|
+| Plugin ID | `v2_custom_rest_resource` | `@RestResource` annotation |
+| Path | `/v2/api/check-update/{country}` | annotation `uri_paths.canonical` |
+| Method | GET | `config/sync/rest.resource.v2_custom_rest_resource.yml` |
+| Auth | `basic_auth` | `config/sync/rest.resource.v2_custom_rest_resource.yml` |
+
+Extends `CustomRestResource` with zero logic changes — identical response at a V2 URL path. Added to support the second app version.
 
 Full response shape documented in [`API_REFERENCE.md` §9](API_REFERENCE.md#9-force-update-rest-resource).
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -453,11 +453,23 @@ Admin settings at `/admin/config/people/email-tfa` (permission: `administer emai
 - OTP: 6 digits, 300s timeout, 5 attempts per hour
 - Dev mode: disabled
 
-### 13.2 Dependencies
+### 13.2 Email notification policy
+
+Only three types of user-facing emails are enabled:
+
+| Email | Source | When |
+|---|---|---|
+| MFA OTP code | `email_tfa` | Every login |
+| Password reset link | `user.settings` (`password_reset`) | User-initiated via `/user/password` |
+| Admin-created account link | `user.settings` (`register_admin_created`) | Admin creates new user |
+
+All content moderation notifications are **disabled** (`status: false`). All other user notifications (`cancel_confirm`, `status_activated`, `register_no_approval_required`, `register_pending_approval`) are **disabled**.
+
+### 13.3 Dependencies
 
 Email TFA depends on working email delivery. If Symfony Mailer / OAuth is not configured, OTP codes cannot be sent and users will be locked out after login. Always verify email delivery before enabling TFA on a new environment.
 
-### 13.3 Troubleshooting MFA
+### 13.4 Troubleshooting MFA
 
 | Symptom | Cause / Fix |
 |---------|-------------|

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -273,7 +273,7 @@ Prod has **no automated deploy job** and the cloud hook explicitly **skips** DB/
 2. Manually run post-deploy steps per site if needed:
 
 ```bash
-DRUSH="php -d memory_limit=1024M vendor/bin/drush @parentbuddy2.prod -l <site_name>"
+DRUSH="php -d memory_limit=1024M vendor/drush/drush/drush.php @parentbuddy2.prod -l <site_name>"
 $DRUSH cr
 $DRUSH updb -y
 $DRUSH cim -y
@@ -395,7 +395,79 @@ See [`DEPENDENCIES.md`](DEPENDENCIES.md) §3.7 and [`ENVIRONMENTS.md`](ENVIRONME
 
 ---
 
-## 12. Troubleshooting
+## 12. Email (Symfony Mailer + Office 365 OAuth)
+
+Email is sent via `drupal/symfony_mailer` with the `drupal/symfony_mailer_office365` transport, using OAuth 2.0 Authorization Code flow against Microsoft 365 (`smtp.office365.com:587`). The `drupal/smtp` module was removed — Basic Auth is blocked by M365 Security Defaults at the tenant level.
+
+### 12.1 Post-deployment OAuth setup (required per environment)
+
+After deploying to a new environment (Stage, Prod), email will **not** work until OAuth is configured.
+
+**Part 1 — Microsoft Entra (client's M365 admin):**
+1. Register an app in Entra admin center → **App registrations** → **New registration**
+   - Name: **Bebbo Site Mailer**
+   - Supported account types: **Single tenant**
+   - Redirect URI: `https://<env-domain>/office365/oauth/callback`
+2. Copy Application (client) ID + Directory (tenant) ID
+3. Create a client secret under **Certificates & secrets** (note the expiry)
+4. Under **API permissions** → Office 365 Exchange Online → Delegated → `SMTP.Send` → Grant admin consent
+5. Confirm Authenticated SMTP is enabled on `admin@bebbo.app` mailbox
+
+**Part 2 — Drupal configuration:**
+1. Navigate to `/admin/config/system/mailer/office365`
+2. Enter: Tenant ID, Client ID, Client Secret
+3. Save and complete the interactive OAuth authorization flow in the browser
+4. Send test email from `/admin/config/system/mailer/transport/office_365_oauth`
+5. Confirm Drupal cron is running regularly (token auto-refresh depends on it)
+
+**Part 3 — Verification:**
+- Test email on all 7 sites: system test email, password reset, content moderation notifications
+- Monitor `/admin/reports/dblog` for mailer errors in first 24 hours
+- Note client secret expiry date for future renewal
+
+### 12.2 Config protection
+
+Two config entries are in `config_ignore` to prevent `drush cim` from overwriting live OAuth credentials:
+- `symfony_mailer.mailer_transport.office_365_oauth`
+- `symfony_mailer_office365.config`
+
+### 12.3 Troubleshooting email
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| "Client not authenticated to send mail" | OAuth token expired or never authorized. Re-run OAuth flow at `/admin/config/system/mailer/office365` |
+| Token refresh failing | Cron not running. Check `drush cron` and `ultimate_cron` status |
+| No emails after deploy | OAuth not configured on this environment. Follow §12.1 |
+| Client secret expired | Rotate secret in Entra, update at `/admin/config/system/mailer/office365` |
+
+---
+
+## 13. Multi-Factor Authentication (Email TFA)
+
+All user logins require email-based OTP verification via `drupal/email_tfa`. After entering username/password, users are redirected to `/tfa/verify/{uid}/{hash}` where they enter a 6-digit code sent to their email. On successful verification, users are redirected to `/dashboard`.
+
+### 13.1 Configuration
+
+Admin settings at `/admin/config/people/email-tfa` (permission: `administer email tfa`):
+- Scope: globally enabled (all users, no role exclusions)
+- OTP: 6 digits, 300s timeout, 5 attempts per hour
+- Dev mode: disabled
+
+### 13.2 Dependencies
+
+Email TFA depends on working email delivery. If Symfony Mailer / OAuth is not configured, OTP codes cannot be sent and users will be locked out after login. Always verify email delivery before enabling TFA on a new environment.
+
+### 13.3 Troubleshooting MFA
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| "OTP not received" | Email delivery broken — check §12 above |
+| User locked out (flood limit) | 5 attempts per hour. Wait, or clear flood table: `drush sqlq "DELETE FROM flood WHERE event = 'email_tfa.failed_login'"` |
+| Redirect loop after login | Anonymous guard in `pb_custom_field_user_login_form_submit()` should prevent this — check if hook is firing |
+
+---
+
+## 14. Troubleshooting
 
 | Symptom | Cause / Fix |
 |---------|-------------|
@@ -408,7 +480,7 @@ See [`DEPENDENCIES.md`](DEPENDENCIES.md) §3.7 and [`ENVIRONMENTS.md`](ENVIRONME
 
 ---
 
-## 13. Related Docs
+## 15. Related Docs
 
 | Topic | Doc |
 |-------|-----|


### PR DESCRIPTION
Covers commits: d0b4744 (Email TFA/MFA), db9cb83+8928549 (SMTP→Symfony Mailer+Office 365 OAuth), b58c82a (status report fixes), 6124c37 (update module), ec68351 (MySQL 5.7 driver), 7372857 (V2 URL aliases), 766790e (deploy hook drush path).

Key documentation changes:
- CONFIGURATION: new Email TFA section, rewritten mail section for OAuth, email_html format, updated config_ignore and moderation notification statuses
- DEPENDENCIES: added email_tfa, symfony_mailer_office365, mysql57, js-cookie; removed smtp, google_analytics, upgrade_status; new patch
- RUNBOOK: new §12 (email OAuth setup/troubleshooting) and §13 (MFA)
- API_REFERENCE: V2 URL aliases for strings and check-update endpoints
- ARCHITECTURE: updated system context diagram (OAuth mail, removed GA), module count 167→171
- CICD/ENVIRONMENTS: drush path vendor/drush/drush/drush.php, MySQL 5.7 driver note, cookie_samesite, post-deploy OAuth section
- MODULES: V2CustomRestResource, MFA hooks in pb_custom_field