### PR TITLE
fix: deploy cleanup hooks + O365 SendAsDenied mail fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -277,6 +277,9 @@
             },
             "drupal/contextual_range_filter": {
                 "Fix PHP 8.4 implicit nullable deprecation in DateRange::init() (https://www.drupal.org/i/3521312)": "patches/contextual_range_filter/3521312-implicit-nullable-php84.patch"
+            },
+            "drupal/symfony_mailer_office365": {
+                "Pass event dispatcher to EsmtpTransport so MessageEvent fires (SendAsDenied fix)": "patches/symfony_mailer_office365-pass-event-dispatcher.patch"
             }
         },
         "drupal-lenient": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "282c6de1fb5369ec6f58aedad960587a",
+    "content-hash": "afe646e7271863fec441f548a24a4208",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/docroot/modules/custom/bebbo_custom_general/bebbo_custom_general.post_update.php
+++ b/docroot/modules/custom/bebbo_custom_general/bebbo_custom_general.post_update.php
@@ -85,6 +85,67 @@ function bebbo_custom_general_post_update_remove_defunct_modules(): string {
 }
 
 /**
+ * Delete stale REST resource configs from removed modules.
+ *
+ * The pb_custom_rest_api module provided custom_rest_resource and
+ * v2_custom_rest_resource plugins. Their rest.resource.* configs crash
+ * cache rebuild after the module is removed. Also cleans up orphaned
+ * pb_custom_form configs whose module was merged into bebbo_custom_general.
+ */
+function bebbo_custom_general_post_update_remove_stale_rest_configs(): string {
+  $config_factory = \Drupal::configFactory();
+  $deleted = [];
+
+  $stale_configs = [
+    'rest.resource.custom_rest_resource',
+    'rest.resource.v2_custom_rest_resource',
+    'pb_custom_form.mobile_app_share_link_form',
+    'pb_custom_form.language_redirects',
+    'pb_custom_form.landing_pages',
+    'pb_custom_form.app_store_redirect',
+    'pb_custom_form.adminsettings',
+  ];
+
+  foreach ($stale_configs as $config_name) {
+    $config = $config_factory->getEditable($config_name);
+    if (!$config->isNew()) {
+      $config->delete();
+      $deleted[] = $config_name;
+    }
+  }
+
+  // Also catch any sites where the first post_update was auto-skipped:
+  // re-run the module removal from core.extension as a safety net.
+  $modules_to_remove = [
+    'custom_serialization',
+    'pb_custom_rest_api',
+    'pb_custom_standard_deviation',
+  ];
+  $config = $config_factory->getEditable('core.extension');
+  $module_list = $config->get('module') ?? [];
+  $extra_removed = [];
+  foreach ($modules_to_remove as $module) {
+    if (array_key_exists($module, $module_list)) {
+      unset($module_list[$module]);
+      $extra_removed[] = $module;
+    }
+  }
+  if ($extra_removed) {
+    $config->set('module', $module_list)->save();
+    \Drupal::database()->delete('key_value')
+      ->condition('collection', 'system.schema')
+      ->condition('name', $modules_to_remove, 'IN')
+      ->execute();
+  }
+
+  $log = $deleted ? 'Deleted stale configs: ' . implode(', ', $deleted) . '. ' : 'No stale configs found. ';
+  if ($extra_removed) {
+    $log .= 'Also removed missed modules: ' . implode(', ', $extra_removed) . '.';
+  }
+  return $log;
+}
+
+/**
  * Removes content stored in languages that are not configured on this site.
  *
  * The Entity Share content pull imported entity translations (and whole

--- a/patches/symfony_mailer_office365-pass-event-dispatcher.patch
+++ b/patches/symfony_mailer_office365-pass-event-dispatcher.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Office365EsmtpTransportFactory.php b/src/Office365EsmtpTransportFactory.php
+index 1234567..abcdefg 100644
+--- a/src/Office365EsmtpTransportFactory.php
++++ b/src/Office365EsmtpTransportFactory.php
+@@ -48,6 +48,7 @@ final class Office365EsmtpTransportFactory extends AbstractTransportFactory {
+     $transport = new EsmtpTransport(
+       host: $dsn->getHost(),
+       port: $dsn->getPort(),
++      dispatcher: $this->dispatcher,
+       authenticators: [$this->authenticator],
+     );
+     $transport->setUsername($dsn->getOption('user'));


### PR DESCRIPTION
## Summary

- **Deploy fix:** Add update/post_update hooks to automatically remove defunct modules (`custom_serialization`, `pb_custom_rest_api`, `pb_custom_standard_deviation`) from active `core.extension` during `drush updb`. Also cleans stale view configs (articles, duplicate_of_tax_test) and REST resource configs that reference removed plugins — prevents `PluginNotFoundException` crash during cache rebuild after deploy.

- **Mail fix:** Patch `drupal/symfony_mailer_office365` to pass the event dispatcher to `EsmtpTransport`. Without this, Symfony's `MessageEvent` is never dispatched, so the `MailerSenderOverride` subscriber (which forces From/Sender to `admin@bebbo.app` for O365 compliance) never fires. Emails go out with the per-site mail (e.g. `info@babuni.app`) causing O365 `SendAsDenied` rejection.

## Root causes

1. Modules deleted from disk but still in active DB `core.extension` → `drush cim` crashes because Drupal can't find them during bootstrap. Post_update hooks run during `updb` (before `cim`) to clean the active state.

2. `Office365EsmtpTransportFactory::create()` constructs `EsmtpTransport` without `dispatcher:` parameter → `AbstractTransport::send()` skips `MessageEvent` dispatch entirely → subscriber is dead code.