### PR TITLE
fix(mail): also inject event_dispatcher into O365 factory service

### DIFF
--- a/patches/symfony_mailer_office365-pass-event-dispatcher.patch
+++ b/patches/symfony_mailer_office365-pass-event-dispatcher.patch
@@ -10,3 +10,16 @@ index 1234567..abcdefg 100644
        authenticators: [$this->authenticator],
      );
      $transport->setUsername($dsn->getOption('user'));
+diff --git a/symfony_mailer_office365.services.yml b/symfony_mailer_office365.services.yml
+index 2345678..bcdefgh 100644
+--- a/symfony_mailer_office365.services.yml
++++ b/symfony_mailer_office365.services.yml
+@@ -1,7 +1,7 @@
+ services:
+   symfony_mailer_office365.esmtp_transport_factory:
+     class: Drupal\symfony_mailer_office365\Office365EsmtpTransportFactory
+-    arguments: ['@symfony_mailer_office365.xoauth2_authenticator']
++    arguments: ['@symfony_mailer_office365.xoauth2_authenticator', '@event_dispatcher']
+     tags:
+       - { name: mailer.transport_factory }
+


### PR DESCRIPTION
The previous patch added dispatcher: to the EsmtpTransport constructor but the factory's own $this->dispatcher was null because services.yml only injected the authenticator. Adding @event_dispatcher as the second argument completes the chain: Drupal dispatcher → factory → transport → MessageEvent dispatched → MailerSenderOverride fires.