### PR TITLE
Fix group-content uploads + improve v2 country-groups logo fields

### DIFF
--- a/config/sync/group.role.country-member.yml
+++ b/config/sync/group.role.country-member.yml
@@ -11,6 +11,7 @@ group_type: country
 permissions:
   - 'access group_node overview'
   - 'view group_membership content'
+  - 'view group_membership entity'
   - 'view latest version'
 admin: false
 scope: insider

--- a/config/sync/views.view.country_listing.yml
+++ b/config/sync/views.view.country_listing.yml
@@ -1140,7 +1140,7 @@ display:
           admin_label: ''
           plugin_id: field
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1714,9 +1714,6 @@ display:
             field_country_email:
               alias: country_email
               raw_output: false
-            field_2_0_branding:
-              alias: all_logos
-              raw_output: false
             field_language:
               alias: langcode
               raw_output: true
@@ -1736,7 +1733,7 @@ display:
               alias: unicef_logo
               raw_output: false
             view_3:
-              alias: field_2_0_branding
+              alias: all_logos
               raw_output: false
       query:
         type: views_query

--- a/config/sync/views.view.country_listing.yml
+++ b/config/sync/views.view.country_listing.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.storage.group.field_app_name
     - field.storage.group.field_content_toggle
     - field.storage.group.field_country_email
+    - field.storage.group.field_country_flag
     - field.storage.group.field_country_national_partner
     - field.storage.group.field_country_sponsor_logo
     - field.storage.group.field_language
@@ -1131,6 +1132,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_country_flag:
+          id: field_country_flag
+          table: group__field_country_flag
+          field: field_country_flag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: true
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         field_2_0_branding:
           id: field_2_0_branding
           table: group__field_2_0_branding
@@ -1587,6 +1650,58 @@ display:
           view: media_details
           display: block_1
           arguments: '{{ raw_fields.field_2_0_branding }}'
+        view_4:
+          id: view_4
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: view
+          label: 'Country Flag'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view: media_details
+          display: block_1
+          arguments: '{{ raw_fields.field_country_flag }}'
       pager:
         type: none
         options:
@@ -1735,6 +1850,9 @@ display:
             view_3:
               alias: all_logos
               raw_output: false
+            view_4:
+              alias: country_flag
+              raw_output: false
       query:
         type: views_query
         options:
@@ -1766,6 +1884,7 @@ display:
         - 'config:field.storage.group.field_app_name'
         - 'config:field.storage.group.field_content_toggle'
         - 'config:field.storage.group.field_country_email'
+        - 'config:field.storage.group.field_country_flag'
         - 'config:field.storage.group.field_country_national_partner'
         - 'config:field.storage.group.field_country_sponsor_logo'
         - 'config:field.storage.group.field_language'

--- a/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
+++ b/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
@@ -1716,6 +1716,7 @@ class BebboSerializer extends Serializer {
       'country_sponsor_logo',
       'unicef_logo',
       'all_logos',
+      'country_flag',
     ];
     foreach ($rows as &$row) {
       foreach ($mediaKeys as $key) {

--- a/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
+++ b/docroot/modules/custom/bebbo_serializer/src/Plugin/views/style/BebboSerializer.php
@@ -1715,7 +1715,7 @@ class BebboSerializer extends Serializer {
       'country_national_partner',
       'country_sponsor_logo',
       'unicef_logo',
-      'field_2_0_branding',
+      'all_logos',
     ];
     foreach ($rows as &$row) {
       foreach ($mediaKeys as $key) {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -890,11 +890,11 @@ Full response (standard envelope; `langcode` resolves to the active/site languag
       "country_email": "admin@babuni.app",
       "app_name": "Babuni",
       "content_toggle": "1, 2",
-      "all_logos": "...",
       "country_national_partner": {"url": "https://example.com/partner.webp", "name": "partner", "alt": "National Partner"},
       "country_sponsor_logo": {"url": "https://example.com/sponsor.webp", "name": "sponsor", "alt": "Sponsor"},
       "unicef_logo": {"url": "https://example.com/unicef.webp", "name": "unicef", "alt": "UNICEF"},
-      "field_2_0_branding": {"url": "https://example.com/branding.webp", "name": "branding", "alt": "Branding"},
+      "all_logos": {"url": "https://example.com/branding.webp", "name": "branding", "alt": "Branding"},
+      "country_flag": {"url": "https://example.com/flag.webp", "name": "flag", "alt": "Country Flag"},
       "languages": [
         {
           "name": "Bangladesh",
@@ -914,11 +914,11 @@ Full response (standard envelope; `langcode` resolves to the active/site languag
       "country_email": "",
       "app_name": "Bebbo",
       "content_toggle": "",
-      "all_logos": "...",
       "country_national_partner": {"url": "", "name": "", "alt": ""},
       "country_sponsor_logo": {"url": "", "name": "", "alt": ""},
       "unicef_logo": {"url": "", "name": "", "alt": ""},
-      "field_2_0_branding": {"url": "", "name": "", "alt": ""},
+      "all_logos": {"url": "", "name": "", "alt": ""},
+      "country_flag": {"url": "", "name": "", "alt": ""},
       "languages": [
         {"name": "Rest of the world", "displayName": "English", "languageCode": "en", "locale": "en_US", "luxonLocale": "en", "pluralShow": "1"},
         {"name": "Rest of the world", "displayName": "Русский", "languageCode": "ru", "locale": "ru_RU", "luxonLocale": "ru", "pluralShow": "1"}
@@ -1109,11 +1109,11 @@ Full response shape:
 | `country_email` | string | Contact email (passthrough) |
 | `app_name` | string | App display name (passthrough) |
 | `content_toggle` | string | Default-language content toggle (overridden by transform from Group entity) |
-| `all_logos` | string | Raw 2.0 branding field (passthrough) |
 | `country_national_partner` | {url,name,alt} | National partner logo (parsed from view embed) |
 | `country_sponsor_logo` | {url,name,alt} | Sponsor logo (parsed from view embed) |
 | `unicef_logo` | {url,name,alt} | UNICEF logo (parsed from view embed) |
-| `field_2_0_branding` | {url,name,alt} | 2.0 branding image (parsed from view embed) |
+| `all_logos` | {url,name,alt} | 2.0 branding image (parsed from view embed, WebP) |
+| `country_flag` | {url,name,alt} | Country flag image (parsed from view embed, WebP) |
 | `languages` | array | Language objects — see below |
 | `displayName` | string | **Only on CountryID 126** ("Rest of the world"); absent on other groups |
 
@@ -1596,7 +1596,8 @@ These fields store **taxonomy term IDs** (integers). The IDs are **subsite-speci
 | `country_national_partner` | Logo image of the national implementing partner organization. |
 | `country_sponsor_logo` | Logo image of the funding sponsor for this country deployment. |
 | `unicef_logo` | UNICEF logo variant used in this country. |
-| `all_logos` / `field_2_0_branding` | Combined branding image for the 2.0 app version. |
+| `all_logos` | Branding image for the 2.0 app version (WebP). |
+| `country_flag` | Flag image for this country (WebP). |
 | `content_toggle` | Comma-separated list of feature IDs to **hide** in the app for this country. Controls which app sections (e.g. growth tracking, vaccinations) are visible. |
 | `languages[].displayName` | Language name as it should appear in the app — usually includes both the local script name and English name. |
 | `languages[].languageCode` | BCP-47 language code used to segregate content in the CMS and APIs. |


### PR DESCRIPTION
## Summary

Fixes a Group permission regression that blocked file/media uploads on group content, and reworks the country-groups logo output in the V2 API (correct `all_logos`, new `country_flag`). All changes live in shared config/serializer code, so they apply to all 7 sites via `cim` on deploy.

---

## Changes

### **fix(group): let country members be referenced as content owners** (`1d19ad6`)

- Enabling Group translation activated Group's user query-access filter, which gates user references by group-membership *entity* visibility.
- The country **Member** role only had `view group_membership content` (the relationship), not `view group_membership entity` (the user), so a member — including the acting user — was filtered out of user reference selection.
- Result: uploads failed with `This entity (user: N) cannot be referenced`.
- Grant `view group_membership entity` to the country Member role.

### **fix(api): expose 2.0 branding logo under `all_logos` as WebP** (`23c822e`)

- `all_logos` previously returned a raw media ID, while the rendered branding image landed under a duplicate `field_2_0_branding` key.
- Mirror the other logo fields:
  - Exclude the raw field.
  - Alias its `media_details` render to `all_logos`.
  - Drop the duplicate key.
  - Point the serializer's media parsing at `all_logos`.
- `all_logos` now returns a WebP `{url, name, alt}` object.

### **feat(api): add `country_flag` to V2 country-groups** (`29550e1`)

- Expose the group `field_country_flag` under a new `country_flag` key, using the same image pattern (raw field → `media_details` render → parsed WebP `{url, name, alt}`).

### **docs: update V2 country-groups logo fields** (`9c19ffd`)

- `API_REFERENCE.md` updated for `all_logos` (WebP object) and `country_flag`.
- Removed the old `field_2_0_branding` output key from examples and tables.

---

## Verification

- **Group permission:** File/media `validate()` returns `0` violations after granting the permission.
- Verified `cim` on a second site confirms the permission propagates correctly.
- **all_logos:** `/v2/api/country-groups/bebbo` returns `all_logos` as a WebP `{url, name, alt}` object; `field_2_0_branding` key is removed.
- **country_flag:** Present on all 16 rows; populated a group's flag and confirmed it renders a WebP `{url, name, alt}` object.
- PHPCS, `drupal-check`, and `phplint` pass cleanly.
- `cim` is a no-op after import.