### PR TITLE
fix(config): update keyword view titles and taxonomy export menu paths

### DIFF
--- a/config/sync/menu_export.export_data.yml
+++ b/config/sync/menu_export.export_data.yml
@@ -2049,7 +2049,7 @@
   menu_name:
     value: editorial-menu
   link:
-    uri: 'internal:/taxonomy-export/en'
+    uri: 'internal:/taxonomy-export'
     title: ''
     options: {  }
   external:
@@ -2231,7 +2231,7 @@
   menu_name:
     value: editorial-menu
   link:
-    uri: 'internal:/taxonomy-export-standard-deviation/en'
+    uri: 'internal:/taxonomy-export-standard-deviation'
     title: ''
     options: {  }
   external:
@@ -2579,3 +2579,4 @@
     value: '1'
   content_translation_created:
     value: '1780403334'
+

--- a/config/sync/views.view.keyword_term_count.yml
+++ b/config/sync/views.view.keyword_term_count.yml
@@ -1442,7 +1442,7 @@ display:
     display_plugin: data_export
     position: 1
     display_options:
-      title: 'Keyword link to content'
+      title: 'Keywords linked to content'
       fields:
         name:
           id: name
@@ -1888,7 +1888,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      title: 'Keyword link to content'
+      title: 'Keywords linked to content'
       fields:
         tid:
           id: tid
@@ -2389,7 +2389,7 @@ display:
     display_plugin: page
     position: 2
     display_options:
-      title: 'Keyword Not linked to content'
+      title: 'Keywords not linked to content'
       fields:
         tid:
           id: tid
@@ -3564,7 +3564,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      title: 'Keyword link to content'
+      title: 'Keywords linked to content'
       fields:
         tid:
           id: tid
@@ -4144,3 +4144,4 @@ display:
         - url.query_args
         - user.permissions
       tags: {  }
+


### PR DESCRIPTION
View keyword_term_count: page titles now match menu labels — "Keywords linked to content" / "Keywords not linked to content". Menu export: taxonomy-export paths drop stale /en suffix.