### PR TITLE
fix(deps): resolve PHP 8.4 deprecations in homepage library and migrate_source_csv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -235,7 +235,7 @@
             "drupal/imagemagick": {
                 "Fix derivative generation - preserve URL-encoded filenames": "patches/imagemagick/fix-url-encoded-filenames.patch"
             },
-             "drupal/date_popup": {
+            "drupal/date_popup": {
                 "Add 1 day to the end so the query will include the selected date.": "https://www.drupal.org/files/issues/2020-10-18/range-selection-end-date-2983680-7.patch"
             },
             "drupal/mobile_app_links": {
@@ -282,6 +282,9 @@
             },
             "drupal/structure_sync": {
                 "PHP 8.4: explicit nullable params (3563762)": "patches/structure_sync-implicit-nullable-php84-3563762.patch"
+            },
+            "drupal/migrate_source_csv": {
+                "Fix league/csv 9.27 createFromStream deprecation": "patches/migrate_source_csv-league_csv_deprecation.patch"
             }
         },
         "drupal-lenient": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bea9a228f672dc7318267de115a889b7",
+    "content-hash": "b038f311dcb4d722c523d70170cbbeab",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",

--- a/docroot/modules/custom/bebbo_custom_general/bebbo_custom_general.post_update.php
+++ b/docroot/modules/custom/bebbo_custom_general/bebbo_custom_general.post_update.php
@@ -392,6 +392,36 @@ function _bebbo_custom_general_referenced_by_valid(string $target_type, $target_
 }
 
 /**
+ * Fix stale enforceIsNew flag on field_description and field_question.
+ *
+ * The D11 upgrade left enforceIsNew=TRUE in the stored field storage
+ * definitions (key_value) while code definitions have NULL. This causes
+ * "Mismatched entity and/or field definitions" on the status report despite
+ * identical schemas. Re-saving the definitions clears the flag.
+ */
+function bebbo_custom_general_post_update_fix_field_definition_mismatch(): string {
+  $manager = \Drupal::entityDefinitionUpdateManager();
+  $code_defs = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node');
+  $fixed = [];
+
+  foreach (['field_description', 'field_question'] as $field_name) {
+    if (!isset($code_defs[$field_name])) {
+      continue;
+    }
+    $installed = $manager->getFieldStorageDefinition($field_name, 'node');
+    if (!$installed) {
+      continue;
+    }
+    $manager->updateFieldStorageDefinition($code_defs[$field_name]);
+    $fixed[] = $field_name;
+  }
+
+  return $fixed
+    ? 'Fixed field definition mismatch for: ' . implode(', ', $fixed)
+    : 'No mismatched field definitions found.';
+}
+
+/**
  * Re-langcodes every row of an entity from orphan languages to a target.
  *
  * Updates the base table plus every data / field / revision table that carries

--- a/docroot/modules/custom/pb_custom_field/pb_custom_field.module
+++ b/docroot/modules/custom/pb_custom_field/pb_custom_field.module
@@ -2157,7 +2157,7 @@ function pb_custom_field_views_pre_render(ViewExecutable $view) {
     }
   }
   if ($view->id() == 'country_content_listing') {
-    $view->element['#attached']['library'][] = '/js/homepage.js';
+    $view->element['#attached']['library'][] = 'pb_custom_field/homepage';
   }
 }
 

--- a/patches/migrate_source_csv-league_csv_deprecation.patch
+++ b/patches/migrate_source_csv-league_csv_deprecation.patch
@@ -1,0 +1,17 @@
+diff --git a/src/Plugin/migrate/source/CSV.php b/src/Plugin/migrate/source/CSV.php
+index 1234567..abcdefg 100644
+--- a/src/Plugin/migrate/source/CSV.php
++++ b/src/Plugin/migrate/source/CSV.php
+@@ -285,11 +285,7 @@ class CSV extends SourcePluginBase implements ConfigurableInterface {
+     if (!file_exists($this->configuration['path'])) {
+       throw new \RuntimeException(sprintf('File "%s" was not found.', $this->configuration['path']));
+     }
+-    $csv = fopen($this->configuration['path'], 'r');
+-    if (!$csv) {
+-      throw new \RuntimeException(sprintf('File "%s" could not be opened.', $this->configuration['path']));
+-    }
+-    return Reader::createFromStream($csv);
++    return Reader::from($this->configuration['path'], 'r');
+   }
+
+ }


### PR DESCRIPTION
- pb_custom_field: replace raw '/js/homepage.js' attachment with 'pb_custom_field/homepage' library reference (fixes dirname(null) deprecation in ExtensionPathResolver on country_content_listing view)
- migrate_source_csv: patch createFromStream() → from() for league/csv 9.27+ deprecation
- bebbo_custom_general: add post_update hook to fix stale enforceIsNew flag on field_description and field_question storage definitions